### PR TITLE
Handle empty values in seed-defaults

### DIFF
--- a/hack/config-operator.sh
+++ b/hack/config-operator.sh
@@ -50,9 +50,9 @@ metadata:
   labels:
     app.kubernetes.io/name: ibmcloud-operator
 data:
-  org: $IC_ORG
-  region: $IC_REGION
-  resourceGroup: $IC_GROUP
-  space: $IC_SPACE
+  org: "${IC_ORG}"
+  region: "${IC_REGION}"
+  resourceGroup: "${IC_GROUP}"
+  space: "${IC_SPACE}"
 EOF
 


### PR DESCRIPTION
If any of the values are empty (particularly the cloud foundry ones) the configmap fails to create.

Wrap org, region, resourceGroup, and space values in double quotes so the configmap is created even if there are empty values