### PR TITLE
Adds support for 'tags' on Service definitions

### DIFF
--- a/config/crds/ibmcloud_v1alpha1_service.yaml
+++ b/config/crds/ibmcloud_v1alpha1_service.yaml
@@ -80,6 +80,10 @@ spec:
                 - name
                 type: object
               type: array
+            tags:
+              items:
+                type: string
+              type: array
             plan:
               type: string
             serviceClass:

--- a/config/samples/cloudant-with-tags.yaml
+++ b/config/samples/cloudant-with-tags.yaml
@@ -1,0 +1,17 @@
+apiVersion: ibmcloud.ibm.com/v1alpha1
+kind: Service
+metadata:
+  name: mycloudant
+spec:
+  plan: lite
+  serviceClass: cloudantnosqldb
+  tags:
+    - cloudant
+    - lite
+---
+apiVersion: ibmcloud.ibm.com/v1alpha1
+kind: Binding
+metadata:
+  name: binding-cloudant
+spec:
+  serviceName: mycloudant

--- a/pkg/apis/ibmcloud/v1alpha1/service_types.go
+++ b/pkg/apis/ibmcloud/v1alpha1/service_types.go
@@ -37,6 +37,8 @@ type ServiceSpec struct {
 	// +optional
 	Parameters []keyvaluev1.KeyValue `json:"parameters,omitempty"`
 	// +optional
+	Tags []string `json:"tags,omitempty"`
+	// +optional
 	Context icv1.ResourceContext `json:"context,omitempty"`
 }
 

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -211,6 +211,8 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	externalName := getExternalName(instance)
 	params := getParams(instance)
+	tags := getTags(instance)
+	logt.Info("ServiceInstance ", "name", externalName, "tags", tags)
 
 	if ibmCloudInfo.ServiceClassType == "CF" {
 		logt.Info("ServiceInstance ", "is CF", instance.ObjectMeta.Name)
@@ -235,6 +237,7 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 				PlanGUID:  ibmCloudInfo.BxPlan.GUID,
 				SpaceGUID: ibmCloudInfo.Space.GUID,
 				Params:    params,
+				Tags:      tags,
 			})
 			if err != nil {
 				return r.updateStatusError(instance, "Failed", err)
@@ -252,6 +255,7 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 					PlanGUID:  ibmCloudInfo.BxPlan.GUID,
 					SpaceGUID: ibmCloudInfo.Space.GUID,
 					Params:    params,
+					Tags:      tags,
 				})
 				if err != nil {
 					return r.updateStatusError(instance, "Failed", err)
@@ -278,6 +282,7 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 			ResourceGroupID: ibmCloudInfo.ResourceGroupID,
 			TargetCrn:       ibmCloudInfo.TargetCrn,
 			Parameters:      params,
+			Tags:            tags,
 		}
 
 		if instance.Status.InstanceID == "" { // ServiceInstance has not been created on Bluemix
@@ -516,4 +521,8 @@ func getParams(instance *ibmcloudv1alpha1.Service) map[string]interface{} {
 		params[p.Name] = p.Value
 	}
 	return params
+}
+
+func getTags(instance *ibmcloudv1alpha1.Service) []string {
+	return instance.Spec.Tags
 }


### PR DESCRIPTION
- Updates CRD to include 'tags' property that can contain an array of strings
- Updates ServiceSpec in service_types to include Tags attribute
- Updates service_controller to pass get tags from the instance and include them in the ServiceInstanceCreateRequest