### PR TITLE
change to use RH UBI image and remove ca-certificates as it is offerr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/ibm/cloud-operators/cmd/manager
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM registry.access.redhat.com/ubi8-minimal
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/ibm/cloud-operators/manager .
 COPY git-rev .


### PR DESCRIPTION
…ed in RH image already

1.  updated to UBI imange
2.  There is 156+ certificates embedded in UBI image, i.e.
```
[root@ibmcloud-operator-8fc4487bb-l6jkz ca-trust]# trust list
pkcs11:id=%d2%87%b4%e3%df%37%27%93%55%f6%56%ea%81%e5%36%cc%8c%1e%3f%bd;type=cert
    type: certificate
    label: ACCVRAIZ1
    trust: anchor
    category: authority

pkcs11:id=%f7%7d%c5%fd%c4%e8%9a%1b%77%64%a7%f5%1d%a0%cc%bf%87%60%9a%6d;type=cert
    type: certificate
    label: AC RAIZ FNMT-RCM
    trust: anchor
    category: authority
......
```
So, no need to install ca-certificates separately. 

3.  I built an personal image to run it in my cluster .  The execution status looks good for me.  
