### PR TITLE
Docs: Explicitly call out serviceClassType for CF

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -123,7 +123,8 @@ spec:
 ```
 
 For CF-type services, the name is unique within a context (org & space), therefore the name is sufficient
-to identify an existing service instance. 
+to identify an existing service instance. Note that the `serviceClassType` must be set to `CF` for the service to be
+recognized by the operator.
 
 For IAM-type services, multiple service instances can have the same name.
 The example above will work only if there is one single instance of the service with that name. If multiple


### PR DESCRIPTION
This is only mentioned in the README but would be good to re-iterate in the user-guide: for Cloud Foundry instances, the `serviceClassType` cannot be omitted and must be set to `CF` to be recognized.