### PR TITLE
add parameters to define sync-period and maxConcurrentReconciles

### DIFF
--- a/pkg/controller/binding/binding_controller.go
+++ b/pkg/controller/binding/binding_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/utils"
 	ibmcloudv1alpha1 "github.com/ibm/cloud-operators/pkg/apis/ibmcloud/v1alpha1"
 	rcontext "github.com/ibm/cloud-operators/pkg/context"
+	commonutils "github.com/ibm/cloud-operators/pkg/controller/common"
 	"github.com/ibm/cloud-operators/pkg/controller/service"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,11 +49,11 @@ import (
 )
 
 var logt = logf.Log.WithName("binding")
+var syncPeriod = commonutils.GetSyncPeriod()
 
 const bindingFinalizer = "binding.ibmcloud.ibm.com"
 const inProgress = "IN PROGRESS"
 const notFound = "Not Found"
-const syncPeriod = time.Second * 150
 const idkey = "ibmcloud.ibm.com/keyId"
 
 // ContainsFinalizer checks if the instance contains service finalizer
@@ -92,7 +93,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("binding-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 1})
+	maxConcurrentReconciles := commonutils.GetMaxConcurrentReconciles()
+	c, err := controller.New("binding-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/common/utils.go
+++ b/pkg/controller/common/utils.go
@@ -1,0 +1,58 @@
+package common
+
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+func GetConfigFromEnv(key string) (string, error) {
+	if os.Getenv(key) != "" {
+		return os.Getenv(key), nil
+	} else {
+		return "", errors.New(fmt.Sprintf("Cannot find %s from from environment variable", key))
+	}
+}
+
+func GetSyncPeriod() time.Duration {
+	defaultSyncPeriod := time.Second * 150
+	syncPeriodStr, err := GetConfigFromEnv("SYNC_PERIOD")
+	if err != nil {
+		return defaultSyncPeriod
+	}
+	syncPeriod, err := time.ParseDuration(syncPeriodStr)
+	if err != nil {
+		return defaultSyncPeriod
+	}
+	return syncPeriod
+}
+
+func GetMaxConcurrentReconciles() int {
+	maxConcurrentReconciles := 1
+	maxConcurrentReconcilesStr, err := GetConfigFromEnv("MAX_CONCURRENT_RECONCILES")
+	if err == nil {
+		maxConcurrentReconciles, err = strconv.Atoi(maxConcurrentReconcilesStr)
+		if err != nil {
+			maxConcurrentReconciles = 1
+		}
+	}
+	return maxConcurrentReconciles
+}

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/models"
 	ibmcloudv1alpha1 "github.com/ibm/cloud-operators/pkg/apis/ibmcloud/v1alpha1"
 	rcontext "github.com/ibm/cloud-operators/pkg/context"
+	commonutils "github.com/ibm/cloud-operators/pkg/controller/common"
 	resv1 "github.com/ibm/cloud-operators/pkg/lib/resource/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,12 +43,10 @@ import (
 )
 
 var logt = logf.Log.WithName("service")
+var syncPeriod = commonutils.GetSyncPeriod()
 
 const serviceFinalizer = "service.ibmcloud.ibm.com"
 const instanceIDKey = "ibmcloud.ibm.com/instanceId"
-
-const syncPeriod = time.Second * 150
-
 const inProgress = "IN PROGRESS"
 
 // ContainsFinalizer checks if the instance contains service finalizer
@@ -87,7 +86,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("service-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 1})
+	maxConcurrentReconciles := commonutils.GetMaxConcurrentReconciles()
+	c, err := controller.New("service-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The original default value is still kept in the code ,  so ibm-cloud-operator can still work by default installation.

To set these parameters,   we can add below in deployment as `env`

```
        - name: SYNC_PERIOD
          value: 1h
        - name: MAX_CONCURRENT_RECONCILES
          value: "5"   
```