### PR TITLE
Correct back-compatible installer to run in old style with old scripts

### DIFF
--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -3,4 +3,7 @@
 
 echo 'WARNING: This installer is deprecated and may be removed in a future version.' >&2
 echo 'Please see here for the most up-to-date install script: https://github.com/ibm/cloud-operators' >&2
-curl -sL https://raw.githubusercontent.com/IBM/cloud-operators/master/hack/configure-operator.sh | bash
+echo >&2
+LATEST_V0_1=0.1.11
+echo "Installing v${LATEST_V0_1}..." >&2
+curl -sL https://raw.githubusercontent.com/IBM/cloud-operators/master/hack/configure-operator.sh | bash -s -- -v "$LATEST_V0_1"


### PR DESCRIPTION
Updates back-compatible install script to install the latest 0.1 version `0.1.11` instead of the latest commit on master.

Conveniently, now users can run `curl ... | bash -s -- -v MAJOR.MINOR.PATCH` to install whichever version they like.