### PR TITLE
Add config-operator.sh to back-compatible install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,19 @@ Notice that the `org` and `space` must be included, even if no Cloud Foundry ser
 
 To install the latest release of the operator, run the following script:
 
-```
+```bash
 curl -sL https://raw.githubusercontent.com/IBM/cloud-operators/master/hack/configure-operator.sh | bash 
 ```
 
 The script above first creates an IBM Cloud API Key and stores it in a Kubernetes secret that can be
 accessed by the operator, then it sets defaults such as the default resource group and region 
 used to provision IBM Cloud Services; finally, it deploys the operator in your cluster. You can always override the defaults in the `Service` custom resource. If you prefer to create the secret and the defaults manually, consult the [IBM Cloud Operator documentation](docs/install.md).
+
+To install a specific version of the operator, you can pass a semantic version:
+
+```bash
+curl -sL https://raw.githubusercontent.com/IBM/cloud-operators/master/hack/configure-operator.sh | bash -s -- -v 0.0.0
+```
 
 ### Using a ServiceId
 
@@ -70,7 +76,7 @@ Next log into the IBM Cloud account that owns the ServiceId and follow the instr
 
 To remove the operator, run the following script:
 
-```
+```bash
 curl -sL https://raw.githubusercontent.com/IBM/cloud-operators/master/hack/configure-operator.sh | bash -s -- delete
 ```
 

--- a/hack/config-operator.sh
+++ b/hack/config-operator.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Back-compatible installer. Simply runs the new installer instead.
+
+echo 'WARNING: This installer is deprecated and may be removed in a future version.' >&2
+echo 'Please see here for the most up-to-date install script: https://github.com/ibm/cloud-operators' >&2
+echo >&2
+LATEST_V0_1=0.1.11
+echo "Setting up creds with v${LATEST_V0_1}..." >&2
+curl -sL https://raw.githubusercontent.com/IBM/cloud-operators/master/hack/configure-operator.sh | bash -s -- -v "$LATEST_V0_1" store-creds

--- a/hack/configure-operator.sh
+++ b/hack/configure-operator.sh
@@ -161,7 +161,7 @@ shift $((OPTIND-1))
 
 ACTION=${1:-apply}
 case "$ACTION" in
-    apply | delete) ;;
+    apply | delete | store-creds) ;;
     *)
         echo "Invalid action: $ACTION" >&2
         echo "Valid actions: delete"
@@ -176,10 +176,15 @@ if [[ "$VERSION" != latest && "$(compare_semver "$VERSION" 0.2.0)" == -1 ]]; the
     curl -sL "https://github.com/IBM/cloud-operators/archive/v${download_version}.zip" > "$tmpzip"
     unzip -qq "$tmpzip"
     pushd "cloud-operators-${download_version}"
-    if [[ "$ACTION" == apply ]]; then
-        ./hack/config-operator.sh
-    fi
-    kubectl "$ACTION" -f "./releases/v${VERSION}"
+    case "$ACTION" in
+        store-creds)
+            ./hack/config-operator.sh
+            ;;
+        *)
+            ./hack/config-operator.sh
+            kubectl "$ACTION" -f "./releases/v${VERSION}"
+            ;;
+    esac
     exit 0
 fi
 
@@ -235,6 +240,10 @@ data:
   space: "${space}"
   user: "${user}"
 EOT
+fi
+
+if [[ "$ACTION" == store-creds ]]; then
+    exit 0
 fi
 
 ## Install ibmcloud-operators


### PR DESCRIPTION
Apparently, `config-operator.sh` was called out directly in the clusterserviceversion.yaml, but not in the README. Adding it in now.