### PR TITLE
Fix OLM data & formatting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ out:
 
 # Prepares Kubernetes yaml files for release. Useful for testing against your own cluster.
 .PHONY: release-prep
-release-prep: kustomize out 
+release-prep: kustomize manifests out 
 	cd config/manager && kustomize edit set image controller=${IMG}
 	kustomize build config/default --output out/
 	go run ./internal/cmd/genolm --version ${RELEASE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -176,3 +176,13 @@ release-prep: kustomize manifests out
 
 .PHONY: release
 release: release-prep docker-push
+
+.PHONY: operator-courier
+operator-courier:
+	@if ! which operator-courier; then \
+		pip3 install operator-courier; \
+	fi
+
+.PHONY: verify-operator-meta
+verify-operator-meta: release-prep operator-courier
+	operator-courier verify --ui_validate_io out/

--- a/Makefile
+++ b/Makefile
@@ -186,3 +186,19 @@ operator-courier:
 .PHONY: verify-operator-meta
 verify-operator-meta: release-prep operator-courier
 	operator-courier verify --ui_validate_io out/
+
+.PHONY: operator-push-test
+operator-push-test: verify-operator-meta
+	# Example values:
+	#
+	# QUAY_NAMESPACE=myuser
+	# QUAY_APP=ibmcloud-operator  NOTE: Must be an application, not a repository.
+	# QUAY_USER=myuser+mybot      NOTE: Bot users are best, so you can manage permissions better.
+	# QUAY_TOKEN=abcdef1234567
+	@for v in "${QUAY_NAMESPACE}" "${QUAY_APP}" "${RELEASE_VERSION}" "${QUAY_USER}" "${QUAY_TOKEN}"; do \
+		if [[ -z "$$v" ]]; then \
+			echo 'Not all Quay variables set. See the make target for details.'; \
+			exit 1; \
+		fi; \
+	done
+	operator-courier push ./out "${QUAY_NAMESPACE}" "${QUAY_APP}" "${RELEASE_VERSION}" "Basic $$(printf "${QUAY_USER}:${QUAY_TOKEN}" | base64)"

--- a/config/crd/bases/ibmcloud.ibm.com_bindings.yaml
+++ b/config/crd/bases/ibmcloud.ibm.com_bindings.yaml
@@ -24,118 +24,6 @@ spec:
     status: {}
   version: v1beta1
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Binding is the Schema for the bindings API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BindingSpec defines the desired state of Binding
-            properties:
-              alias:
-                type: string
-              parameters:
-                items:
-                  description: Param represents a key-value pair
-                  properties:
-                    attributes:
-                      additionalProperties:
-                        type: object
-                      description: A parameter may have attributes (e.g. message hub
-                        topic might have partitions)
-                      type: object
-                    name:
-                      description: Name representing the key.
-                      type: string
-                    value:
-                      description: Defaults to null.
-                    valueFrom:
-                      description: Source for the value. Cannot be used if value is
-                        not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a secret in the resource namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              role:
-                type: string
-              secretName:
-                type: string
-              serviceName:
-                type: string
-              serviceNamespace:
-                type: string
-            required:
-            - serviceName
-            type: object
-          status:
-            description: BindingStatus defines the observed state of Binding
-            properties:
-              generation:
-                format: int64
-                type: integer
-              instanceId:
-                type: string
-              keyInstanceId:
-                type: string
-              message:
-                type: string
-              secretName:
-                type: string
-              state:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: false
   - name: v1beta1
     schema:
       openAPIV3Schema:
@@ -263,6 +151,118 @@ spec:
         type: object
     served: true
     storage: true
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Binding is the Schema for the bindings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BindingSpec defines the desired state of Binding
+            properties:
+              alias:
+                type: string
+              parameters:
+                items:
+                  description: Param represents a key-value pair
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: object
+                      description: A parameter may have attributes (e.g. message hub
+                        topic might have partitions)
+                      type: object
+                    name:
+                      description: Name representing the key.
+                      type: string
+                    value:
+                      description: Defaults to null.
+                    valueFrom:
+                      description: Source for the value. Cannot be used if value is
+                        not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the resource namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              role:
+                type: string
+              secretName:
+                type: string
+              serviceName:
+                type: string
+              serviceNamespace:
+                type: string
+            required:
+            - serviceName
+            type: object
+          status:
+            description: BindingStatus defines the observed state of Binding
+            properties:
+              generation:
+                format: int64
+                type: integer
+              instanceId:
+                type: string
+              keyInstanceId:
+                type: string
+              message:
+                type: string
+              secretName:
+                type: string
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/ibmcloud.ibm.com_bindings.yaml
+++ b/config/crd/bases/ibmcloud.ibm.com_bindings.yaml
@@ -22,7 +22,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
+  version: v1beta1
   versions:
   - name: v1alpha1
     schema:

--- a/config/crd/bases/ibmcloud.ibm.com_services.yaml
+++ b/config/crd/bases/ibmcloud.ibm.com_services.yaml
@@ -24,232 +24,6 @@ spec:
     status: {}
   version: v1beta1
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Service is the Schema for the services API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ServiceSpec defines the desired state of Service
-            properties:
-              context:
-                description: ResourceContext defines the CloudFoundry context and
-                  resource group
-                properties:
-                  org:
-                    type: string
-                  region:
-                    type: string
-                  resourcegroup:
-                    type: string
-                  resourcegroupid:
-                    type: string
-                  resourcelocation:
-                    type: string
-                  space:
-                    type: string
-                  user:
-                    type: string
-                type: object
-              externalName:
-                type: string
-              parameters:
-                items:
-                  description: Param represents a key-value pair
-                  properties:
-                    attributes:
-                      additionalProperties:
-                        type: object
-                      description: A parameter may have attributes (e.g. message hub
-                        topic might have partitions)
-                      type: object
-                    name:
-                      description: Name representing the key.
-                      type: string
-                    value:
-                      description: Defaults to null.
-                    valueFrom:
-                      description: Source for the value. Cannot be used if value is
-                        not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a secret in the resource namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              plan:
-                type: string
-              serviceClass:
-                type: string
-              serviceClassType:
-                type: string
-              tags:
-                items:
-                  type: string
-                type: array
-            required:
-            - plan
-            - serviceClass
-            type: object
-          status:
-            description: ServiceStatus defines the observed state of Service
-            properties:
-              context:
-                description: ResourceContext defines the CloudFoundry context and
-                  resource group
-                properties:
-                  org:
-                    type: string
-                  region:
-                    type: string
-                  resourcegroup:
-                    type: string
-                  resourcegroupid:
-                    type: string
-                  resourcelocation:
-                    type: string
-                  space:
-                    type: string
-                  user:
-                    type: string
-                type: object
-              dashboardURL:
-                type: string
-              externalName:
-                type: string
-              generation:
-                format: int64
-                type: integer
-              instanceId:
-                type: string
-              message:
-                type: string
-              parameters:
-                items:
-                  description: Param represents a key-value pair
-                  properties:
-                    attributes:
-                      additionalProperties:
-                        type: object
-                      description: A parameter may have attributes (e.g. message hub
-                        topic might have partitions)
-                      type: object
-                    name:
-                      description: Name representing the key.
-                      type: string
-                    value:
-                      description: Defaults to null.
-                    valueFrom:
-                      description: Source for the value. Cannot be used if value is
-                        not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a secret in the resource namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              plan:
-                type: string
-              serviceClass:
-                type: string
-              serviceClassType:
-                type: string
-              state:
-                type: string
-              tags:
-                items:
-                  type: string
-                type: array
-            required:
-            - plan
-            - serviceClass
-            - serviceClassType
-            type: object
-        type: object
-    served: true
-    storage: false
   - name: v1beta1
     schema:
       openAPIV3Schema:
@@ -490,6 +264,232 @@ spec:
         type: object
     served: true
     storage: true
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Service is the Schema for the services API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceSpec defines the desired state of Service
+            properties:
+              context:
+                description: ResourceContext defines the CloudFoundry context and
+                  resource group
+                properties:
+                  org:
+                    type: string
+                  region:
+                    type: string
+                  resourcegroup:
+                    type: string
+                  resourcegroupid:
+                    type: string
+                  resourcelocation:
+                    type: string
+                  space:
+                    type: string
+                  user:
+                    type: string
+                type: object
+              externalName:
+                type: string
+              parameters:
+                items:
+                  description: Param represents a key-value pair
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: object
+                      description: A parameter may have attributes (e.g. message hub
+                        topic might have partitions)
+                      type: object
+                    name:
+                      description: Name representing the key.
+                      type: string
+                    value:
+                      description: Defaults to null.
+                    valueFrom:
+                      description: Source for the value. Cannot be used if value is
+                        not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the resource namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              plan:
+                type: string
+              serviceClass:
+                type: string
+              serviceClassType:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - plan
+            - serviceClass
+            type: object
+          status:
+            description: ServiceStatus defines the observed state of Service
+            properties:
+              context:
+                description: ResourceContext defines the CloudFoundry context and
+                  resource group
+                properties:
+                  org:
+                    type: string
+                  region:
+                    type: string
+                  resourcegroup:
+                    type: string
+                  resourcegroupid:
+                    type: string
+                  resourcelocation:
+                    type: string
+                  space:
+                    type: string
+                  user:
+                    type: string
+                type: object
+              dashboardURL:
+                type: string
+              externalName:
+                type: string
+              generation:
+                format: int64
+                type: integer
+              instanceId:
+                type: string
+              message:
+                type: string
+              parameters:
+                items:
+                  description: Param represents a key-value pair
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: object
+                      description: A parameter may have attributes (e.g. message hub
+                        topic might have partitions)
+                      type: object
+                    name:
+                      description: Name representing the key.
+                      type: string
+                    value:
+                      description: Defaults to null.
+                    valueFrom:
+                      description: Source for the value. Cannot be used if value is
+                        not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the resource namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              plan:
+                type: string
+              serviceClass:
+                type: string
+              serviceClassType:
+                type: string
+              state:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - plan
+            - serviceClass
+            - serviceClassType
+            type: object
+        type: object
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/ibmcloud.ibm.com_services.yaml
+++ b/config/crd/bases/ibmcloud.ibm.com_services.yaml
@@ -22,7 +22,7 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
+  version: v1beta1
   versions:
   - name: v1alpha1
     schema:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,11 @@ spec:
         - /manager
         args:
         - --enable-leader-election
+        env:
+        - name: CONTROLLER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: controller:latest
         name: manager
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            # TODO(johnstarich): Reduce back to 30Mi once this is resolved: https://github.com/IBM/cloud-operators/issues/199
+            memory: 125Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/controllers/token_controller.go
+++ b/controllers/token_controller.go
@@ -127,15 +127,9 @@ func (r *TokenReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
 		WithEventFilter(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
-				return shouldProcessSecret(e.Meta)
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				return shouldProcessSecret(e.Meta)
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				return shouldProcessSecret(e.MetaNew)
-			},
+			CreateFunc: func(e event.CreateEvent) bool { return shouldProcessSecret(e.Meta) },
+			DeleteFunc: func(e event.DeleteEvent) bool { return shouldProcessSecret(e.Meta) },
+			UpdateFunc: func(e event.UpdateEvent) bool { return shouldProcessSecret(e.MetaNew) },
 		}).
 		Complete(r)
 }

--- a/controllers/token_controller.go
+++ b/controllers/token_controller.go
@@ -28,6 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	secretLabelName  = "app.kubernetes.io/name"
+	secretLabelValue = "ibmcloud-operator"
 )
 
 // TokenReconciler reconciles a Token object
@@ -118,5 +125,20 @@ func (r *TokenReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 func (r *TokenReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return shouldProcessSecret(e.Meta)
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return shouldProcessSecret(e.Meta)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return shouldProcessSecret(e.MetaNew)
+			},
+		}).
 		Complete(r)
+}
+
+func shouldProcessSecret(meta metav1.Object) bool {
+	return meta.GetLabels()[secretLabelName] == secretLabelValue
 }

--- a/controllers/token_controller.go
+++ b/controllers/token_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -33,8 +34,8 @@ import (
 )
 
 const (
-	secretLabelName  = "app.kubernetes.io/name"
-	secretLabelValue = "ibmcloud-operator"
+	icoSecretName = "secret-ibm-cloud-operator"
+	icoTokensName = "secret-ibm-cloud-operator-tokens"
 )
 
 // TokenReconciler reconciles a Token object
@@ -97,7 +98,7 @@ func (r *TokenReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err // requeue
 	}
 
-	tokensRef := secret.Name + "-tokens"
+	tokensRef := strings.TrimSuffix(secret.Name, icoSecretName) + icoTokensName // need to trim suffix, since management namespace could be the prefix
 	logt.Info("creating tokens secret", "name", tokensRef)
 
 	tokens := &corev1.Secret{
@@ -140,5 +141,5 @@ func (r *TokenReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func shouldProcessSecret(meta metav1.Object) bool {
-	return meta.GetLabels()[secretLabelName] == secretLabelValue
+	return meta.GetName() == icoSecretName || strings.HasSuffix(meta.GetName(), "-"+icoSecretName)
 }

--- a/controllers/token_controller_test.go
+++ b/controllers/token_controller_test.go
@@ -320,3 +320,15 @@ func TestTokenRaceCreateFailed(t *testing.T) {
 	assert.True(t, k8sErrors.IsAlreadyExists(err))
 	assert.Equal(t, ctrl.Result{}, result)
 }
+
+func TestShouldProcessSecret(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal secret", func(t *testing.T) {
+		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"}))
+	})
+
+	t.Run("management namespace secret", func(t *testing.T) {
+		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "mynamespace-secret-ibm-cloud-operator"}))
+	})
+}

--- a/controllers/token_controller_test.go
+++ b/controllers/token_controller_test.go
@@ -31,7 +31,7 @@ func TestToken(t *testing.T) {
 
 	// Create the secret object and expect the Reconcile
 	const (
-		secretName   = "dummyapikey"
+		secretName   = "secret-ibm-cloud-operator"
 		secretAPIKey = "VExS246avaUT6MXZ56SH_I-AeWo_-JmW0u79Jd8LiBH" // nolint:gosec // Fake API key
 	)
 
@@ -62,7 +62,7 @@ func TestToken(t *testing.T) {
 
 	var secret corev1.Secret
 	assert.Eventually(t, func() bool {
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "dummyapikey-tokens"}, &secret)
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "secret-ibm-cloud-operator-tokens"}, &secret)
 		if err != nil {
 			t.Log("Failed to get secret:", err)
 			return false

--- a/controllers/token_controller_test.go
+++ b/controllers/token_controller_test.go
@@ -83,7 +83,7 @@ func TestTokenFailedAuth(t *testing.T) {
 	scheme := schemas(t)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
 			Data: map[string][]byte{
 				"api-key": []byte(`bogus key`),
 			},
@@ -99,7 +99,7 @@ func TestTokenFailedAuth(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret"},
+		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 	})
 	assert.EqualError(t, err, "failure")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -117,7 +117,7 @@ func TestTokenFailedSecretLookup(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		result, err := r.Reconcile(ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "secret"},
+			NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 		})
 		assert.NoError(t, err, "Don't retry (return err) if secret no longer exists")
 		assert.Equal(t, ctrl.Result{}, result)
@@ -126,7 +126,7 @@ func TestTokenFailedSecretLookup(t *testing.T) {
 	r.Client = fake.NewFakeClientWithScheme(runtime.NewScheme()) // fail to read the type Secret
 	t.Run("failed to read secret", func(t *testing.T) {
 		result, err := r.Reconcile(ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "secret"},
+			NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 		})
 		assert.Error(t, err)
 		assert.False(t, k8sErrors.IsNotFound(err))
@@ -141,7 +141,7 @@ func TestTokenSecretIsDeleting(t *testing.T) {
 	objects := []runtime.Object{
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:              "secret",
+				Name:              "secret-ibm-cloud-operator",
 				DeletionTimestamp: now,
 			},
 		},
@@ -154,7 +154,7 @@ func TestTokenSecretIsDeleting(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret"},
+		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 	})
 	assert.NoError(t, err, "Don't retry (return err) if secret is deleting")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -165,7 +165,7 @@ func TestTokenAPIKeyIsMissing(t *testing.T) {
 	scheme := schemas(t)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
 			Data:       nil, // no API key
 		},
 	}
@@ -177,7 +177,7 @@ func TestTokenAPIKeyIsMissing(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret"},
+		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 	})
 	assert.NoError(t, err, "Don't retry (return err) if secret does not contain an api-key entry")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -192,7 +192,7 @@ func TestTokenAuthInvalidConfig(t *testing.T) {
 	)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
 			Data: map[string][]byte{
 				"api-key": []byte(apiKey),
 				"region":  []byte(region),
@@ -211,7 +211,7 @@ func TestTokenAuthInvalidConfig(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret"},
+		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 	})
 	assert.NoError(t, err, "Don't retry (return err) if secret region is invalid")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -227,7 +227,7 @@ func TestTokenDeleteFailed(t *testing.T) {
 	)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
 			Data: map[string][]byte{
 				"api-key": []byte(apiKey),
 				"region":  []byte(region),
@@ -250,7 +250,7 @@ func TestTokenDeleteFailed(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret"},
+		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 	})
 	assert.Error(t, err)
 	assert.False(t, k8sErrors.IsNotFound(err))
@@ -266,14 +266,14 @@ func TestTokenRaceCreateFailed(t *testing.T) {
 		accessToken = "some access token"
 	)
 	tokensSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "secret-tokens"},
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator-tokens"},
 		Data: map[string][]byte{
 			"access_token": []byte("old " + accessToken),
 		},
 	}
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
 			Data: map[string][]byte{
 				"api-key": []byte(apiKey),
 				"region":  []byte(region),
@@ -312,7 +312,7 @@ func TestTokenRaceCreateFailed(t *testing.T) {
 	var err error
 	require.Eventually(t, func() bool {
 		result, err = r.Reconcile(ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "secret"},
+			NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
 		})
 		return err != nil
 	}, 5*time.Second, 10*time.Millisecond)

--- a/internal/cmd/fixcrd/main.go
+++ b/internal/cmd/fixcrd/main.go
@@ -7,6 +7,9 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"sort"
+	"strings"
+	"unicode"
 
 	"gopkg.in/yaml.v2"
 )
@@ -51,6 +54,9 @@ func mutateYaml(r io.Reader, w io.Writer) error {
 	}
 
 	removeValueType(&yamlData, false)
+	versions := getVersions(yamlData)
+	version := latestVersion(versions)
+	setVersion(&yamlData, version, 0)
 	return yaml.NewEncoder(w).Encode(yamlData)
 }
 
@@ -96,4 +102,95 @@ func ptrSetter(v interface{}) (value interface{}, setPtr func(interface{})) {
 	return val.Interface(), func(newValue interface{}) {
 		val.Set(reflect.ValueOf(newValue))
 	}
+}
+
+func setVersion(v interface{}, version string, depth int) {
+	const maxDepth = 3
+	if depth > maxDepth {
+		return
+	}
+	depth++
+
+	d, set := ptrSetter(v)
+	switch d := d.(type) {
+	case []interface{}:
+		newSlice := make([]interface{}, 0, len(d))
+		for ix := range d {
+			item := d[ix]
+			setVersion(&item, version, depth)
+			newSlice = append(newSlice, item)
+		}
+		set(newSlice)
+	case yaml.MapSlice:
+		newSlice := make(yaml.MapSlice, 0, len(d))
+		for ix := range d {
+			item := d[ix]
+			setVersion(&item, version, depth)
+			newSlice = append(newSlice, item)
+		}
+		set(newSlice)
+	case yaml.MapItem:
+		setVersion(&d.Value, version, depth)
+		if d.Key == "version" {
+			d.Value = version
+		}
+		set(d)
+	}
+}
+
+func getVersions(v interface{}) (versions []string) {
+	return recursiveGetVersions(v, false)
+}
+
+func recursiveGetVersions(v interface{}, foundVersions bool) (versions []string) {
+	switch d := v.(type) {
+	case []interface{}:
+		for ix := range d {
+			item := d[ix]
+			versions = append(versions, recursiveGetVersions(item, foundVersions)...)
+		}
+	case yaml.MapSlice:
+		for ix := range d {
+			item := d[ix]
+			versions = append(versions, recursiveGetVersions(item, foundVersions)...)
+		}
+	case yaml.MapItem:
+		if d.Key == "versions" {
+			return recursiveGetVersions(d.Value, true)
+		}
+		if !foundVersions {
+			return append(versions, recursiveGetVersions(d.Value, foundVersions)...)
+		}
+		if d.Key != "name" {
+			return
+		}
+		return append(versions, d.Value.(string))
+	}
+	return
+}
+
+func latestVersion(versions []string) string {
+	// sort versions lowest to highest. i.e. v1alpha1, v1beta1, v1beta2, v1
+	sort.Slice(versions, func(a, b int) bool {
+		strA := versions[a]
+		strB := versions[b]
+		// artificially sort 'v1' as greater than 'v1alpha1'. this works because '~' > 'a-zA-Z'
+		if isDigits(strings.TrimPrefix(strA, "v")) {
+			strA += "~"
+		}
+		if isDigits(strings.TrimPrefix(strB, "v")) {
+			strA += "~"
+		}
+		return strA < strB
+	})
+	return versions[len(versions)-1]
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cmd/genolm/crd.go
+++ b/internal/cmd/genolm/crd.go
@@ -23,6 +23,7 @@ type CRD struct {
 	SpecDescriptors   []Descriptor `json:"specDescriptors,omitempty"`
 	StatusDescriptors []Descriptor `json:"statusDescriptors,omitempty"`
 	ActionDescriptors []Descriptor `json:"actionDescriptors,omitempty"`
+	Version           string       `json:"version"`
 }
 
 type TypeMeta struct {
@@ -101,6 +102,7 @@ func NewCRD(src apiextensionsv1beta1.CustomResourceDefinition, ownedResources []
 		OwnedResources:    ownedResources,
 		SpecDescriptors:   descriptorsFor("spec", latestVersion, xDescriptors),
 		StatusDescriptors: descriptorsFor("status", latestVersion, xDescriptors),
+		Version:           src.Spec.Version,
 	}
 }
 

--- a/internal/cmd/genolm/deployments.go
+++ b/internal/cmd/genolm/deployments.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type Deployment struct {
+	Name string                `json:"name"`
+	Spec appsv1.DeploymentSpec `json:"spec"`
+}
+
+func getDeployments(output string) ([]Deployment, error) {
+	var deployment appsv1.Deployment
+	deploymentBytes, err := ioutil.ReadFile(filepath.Join(output, "apps_v1_deployment_ibmcloud-operators-controller-manager.yaml"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Error reading generated deployment file. Did kustomize run yet?")
+	}
+	err = yaml.Unmarshal(deploymentBytes, &deployment)
+	return []Deployment{
+		{Name: deployment.Name, Spec: deployment.Spec},
+	}, err
+}

--- a/internal/cmd/genolm/main.go
+++ b/internal/cmd/genolm/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -36,7 +35,7 @@ func main() {
 
 type Data struct {
 	CRDs           []CRD
-	DeploymentSpec appsv1.DeploymentSpec
+	Deployments    []Deployment
 	Examples       []runtime.RawExtension
 	Image          string
 	Maintainers    []Maintainer
@@ -96,17 +95,10 @@ func run(output, repoRoot, versionStr string) error {
 		return err
 	}
 
-	// DeploymentSpec
-	var deployment appsv1.Deployment
-	deploymentBytes, err := ioutil.ReadFile(filepath.Join(output, "apps_v1_deployment_ibmcloud-operators-controller-manager.yaml"))
-	if err != nil {
-		return errors.Wrap(err, "Error reading generated deployment file. Did kustomize run yet?")
-	}
-	err = yaml.Unmarshal(deploymentBytes, &deployment)
+	deployments, err := getDeployments(output)
 	if err != nil {
 		return err
 	}
-	deploymentSpec := deployment.Spec
 
 	rbac, err := getRBAC(output)
 	if err != nil {
@@ -125,7 +117,7 @@ func run(output, repoRoot, versionStr string) error {
 
 	data := Data{
 		CRDs:           crds,
-		DeploymentSpec: deploymentSpec,
+		Deployments:    deployments,
 		Examples:       samples,
 		Image:          "cloudoperators/ibmcloud-operator",
 		Maintainers:    maintainers,

--- a/internal/cmd/genolm/main.go
+++ b/internal/cmd/genolm/main.go
@@ -210,6 +210,9 @@ func getRBAC(output string) (clusterRoles, roles roleRules, err error) {
 			clusterRoles.Rules = append(clusterRoles.Rules, role.Rules...)
 		case "Role":
 			roles.Rules = append(roles.Rules, role.Rules...)
+		case "ClusterRoleBinding", "RoleBinding": // role bindings don't translate into the RBAC sections
+		default:
+			panic("Unrecognized role type: " + kind)
 		}
 	}
 	return clusterRoles, roles, nil

--- a/internal/cmd/genolm/templates/clusterserviceversion.yaml
+++ b/internal/cmd/genolm/templates/clusterserviceversion.yaml
@@ -53,7 +53,9 @@ spec:
     strategy: deployment
     spec:
       clusterPermissions:
-      {{.RBAC | yaml | indent 6 | trimSpace}}
+      {{.ClusterRoles | yaml | indent 6 | trimSpace}}
+      permissions:
+      {{.Roles | yaml | indent 6 | trimSpace}}
       deployments: 
       {{.Deployments | yaml | indent 6 | trimSpace}}
   customresourcedefinitions:

--- a/internal/cmd/genolm/templates/clusterserviceversion.yaml
+++ b/internal/cmd/genolm/templates/clusterserviceversion.yaml
@@ -55,7 +55,7 @@ spec:
       clusterPermissions:
       {{.RBAC | yaml | indent 6 | trimSpace}}
       deployments: 
-      - {{.DeploymentSpec | yaml | indent 8 | trimSpace}}
+      {{.Deployments | yaml | indent 6 | trimSpace}}
   customresourcedefinitions:
     owned:
       {{.CRDs | yaml | indent 6 | trimSpace}}


### PR DESCRIPTION
Fixes OLM metadata so it will install properly from Operator Hub for v0.2+. Adds make tasks to assists OLM testing.
Bumps the memory limit to mitigate an OOMKilled issue when running in OpenShift 4.4 (i.e. lots of built-in secrets). Opened #199 to look into it further.

Also update TokenController to skip processing any secret not using the well-known names. e.g. `secret-ibm-cloud-operator` `<namespace>-secret-ibm-cloud-operator`