### PR TITLE
break: Use consistent resource names for v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install: manifests kustomize
 .PHONY: uninstall
 uninstall: manifests kustomize
 	kustomize build config/crd | kubectl delete -f -
-	kubectl delete secret/secret-ibm-cloud-operator configmap/config-ibm-cloud-operator
+	kubectl delete secret/ibmcloud-operator-secret configmap/ibmcloud-operator-defaults
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: ibmcloud-operators-system
+namespace: ibmcloud-operator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: ibmcloud-operators-
+namePrefix: ibmcloud-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: ibmcloud-operators-system
+  name: ibmcloud-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/controllers/binding_controller_test.go
+++ b/controllers/binding_controller_test.go
@@ -514,7 +514,7 @@ func TestBindingGetIBMCloudInfoFailed(t *testing.T) {
 					fake.NewFakeClientWithScheme(scheme, objects...),
 					MockConfig{UpdateErr: fmt.Errorf("failed")},
 				)
-				return nil, errors.NewNotFound(ctrl.GroupResource{Group: "ibmcloud.ibm.com", Resource: "secret"}, "secret-ibm-cloud-operator")
+				return nil, errors.NewNotFound(ctrl.GroupResource{Group: "ibmcloud.ibm.com", Resource: "secret"}, "ibmcloud-operator-secret")
 			},
 		}
 

--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -321,7 +321,7 @@ func TestServiceGetIBMCloudInfoFailed(t *testing.T) {
 			Scheme: scheme,
 
 			GetIBMCloudInfo: func(logt logr.Logger, _ client.Client, instance *ibmcloudv1beta1.Service) (*ibmcloud.Info, error) {
-				return nil, errors.NewNotFound(ctrl.GroupResource{Group: "ibmcloud.ibm.com", Resource: "secret"}, "secret-ibm-cloud-operator")
+				return nil, errors.NewNotFound(ctrl.GroupResource{Group: "ibmcloud.ibm.com", Resource: "secret"}, "ibmcloud-operator-secret")
 			},
 		}
 

--- a/controllers/suite_config_test.go
+++ b/controllers/suite_config_test.go
@@ -49,7 +49,7 @@ func setupConfigs() error {
 
 	err := k8sClient.Create(ctx, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-ibm-cloud-operator",
+			Name:      "ibmcloud-operator-defaults",
 			Namespace: testNamespace,
 		},
 		Data: map[string]string{
@@ -66,7 +66,7 @@ func setupConfigs() error {
 
 	err = k8sClient.Create(ctx, &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret-ibm-cloud-operator",
+			Name:      "ibmcloud-operator-secret",
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
@@ -79,7 +79,7 @@ func setupConfigs() error {
 
 	return k8sClient.Create(ctx, &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret-ibm-cloud-operator-tokens",
+			Name:      "ibmcloud-operator-tokens",
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{

--- a/controllers/token_controller.go
+++ b/controllers/token_controller.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	icoSecretName = "secret-ibm-cloud-operator"
-	icoTokensName = "secret-ibm-cloud-operator-tokens"
+	icoSecretName = "ibmcloud-operator-secret"
+	icoTokensName = "ibmcloud-operator-tokens"
 )
 
 // TokenReconciler reconciles a Token object

--- a/controllers/token_controller_test.go
+++ b/controllers/token_controller_test.go
@@ -31,7 +31,7 @@ func TestToken(t *testing.T) {
 
 	// Create the secret object and expect the Reconcile
 	const (
-		secretName   = "secret-ibm-cloud-operator"
+		secretName   = "ibmcloud-operator-secret"
 		secretAPIKey = "VExS246avaUT6MXZ56SH_I-AeWo_-JmW0u79Jd8LiBH" // nolint:gosec // Fake API key
 	)
 
@@ -62,7 +62,7 @@ func TestToken(t *testing.T) {
 
 	var secret corev1.Secret
 	assert.Eventually(t, func() bool {
-		err := k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "secret-ibm-cloud-operator-tokens"}, &secret)
+		err := k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "ibmcloud-operator-tokens"}, &secret)
 		if err != nil {
 			t.Log("Failed to get secret:", err)
 			return false
@@ -83,7 +83,7 @@ func TestTokenFailedAuth(t *testing.T) {
 	scheme := schemas(t)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ibmcloud-operator-secret"},
 			Data: map[string][]byte{
 				"api-key": []byte(`bogus key`),
 			},
@@ -99,7 +99,7 @@ func TestTokenFailedAuth(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+		NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 	})
 	assert.EqualError(t, err, "failure")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -117,7 +117,7 @@ func TestTokenFailedSecretLookup(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		result, err := r.Reconcile(ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+			NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 		})
 		assert.NoError(t, err, "Don't retry (return err) if secret no longer exists")
 		assert.Equal(t, ctrl.Result{}, result)
@@ -126,7 +126,7 @@ func TestTokenFailedSecretLookup(t *testing.T) {
 	r.Client = fake.NewFakeClientWithScheme(runtime.NewScheme()) // fail to read the type Secret
 	t.Run("failed to read secret", func(t *testing.T) {
 		result, err := r.Reconcile(ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+			NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 		})
 		assert.Error(t, err)
 		assert.False(t, k8sErrors.IsNotFound(err))
@@ -141,7 +141,7 @@ func TestTokenSecretIsDeleting(t *testing.T) {
 	objects := []runtime.Object{
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:              "secret-ibm-cloud-operator",
+				Name:              "ibmcloud-operator-secret",
 				DeletionTimestamp: now,
 			},
 		},
@@ -154,7 +154,7 @@ func TestTokenSecretIsDeleting(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+		NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 	})
 	assert.NoError(t, err, "Don't retry (return err) if secret is deleting")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -165,7 +165,7 @@ func TestTokenAPIKeyIsMissing(t *testing.T) {
 	scheme := schemas(t)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ibmcloud-operator-secret"},
 			Data:       nil, // no API key
 		},
 	}
@@ -177,7 +177,7 @@ func TestTokenAPIKeyIsMissing(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+		NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 	})
 	assert.NoError(t, err, "Don't retry (return err) if secret does not contain an api-key entry")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -192,7 +192,7 @@ func TestTokenAuthInvalidConfig(t *testing.T) {
 	)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ibmcloud-operator-secret"},
 			Data: map[string][]byte{
 				"api-key": []byte(apiKey),
 				"region":  []byte(region),
@@ -211,7 +211,7 @@ func TestTokenAuthInvalidConfig(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+		NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 	})
 	assert.NoError(t, err, "Don't retry (return err) if secret region is invalid")
 	assert.Equal(t, ctrl.Result{}, result)
@@ -227,7 +227,7 @@ func TestTokenDeleteFailed(t *testing.T) {
 	)
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ibmcloud-operator-secret"},
 			Data: map[string][]byte{
 				"api-key": []byte(apiKey),
 				"region":  []byte(region),
@@ -250,7 +250,7 @@ func TestTokenDeleteFailed(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+		NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 	})
 	assert.Error(t, err)
 	assert.False(t, k8sErrors.IsNotFound(err))
@@ -266,14 +266,14 @@ func TestTokenRaceCreateFailed(t *testing.T) {
 		accessToken = "some access token"
 	)
 	tokensSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator-tokens"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ibmcloud-operator-tokens"},
 		Data: map[string][]byte{
 			"access_token": []byte("old " + accessToken),
 		},
 	}
 	objects := []runtime.Object{
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ibmcloud-operator-secret"},
 			Data: map[string][]byte{
 				"api-key": []byte(apiKey),
 				"region":  []byte(region),
@@ -312,7 +312,7 @@ func TestTokenRaceCreateFailed(t *testing.T) {
 	var err error
 	require.Eventually(t, func() bool {
 		result, err = r.Reconcile(ctrl.Request{
-			NamespacedName: types.NamespacedName{Name: "secret-ibm-cloud-operator"},
+			NamespacedName: types.NamespacedName{Name: "ibmcloud-operator-secret"},
 		})
 		return err != nil
 	}, 5*time.Second, 10*time.Millisecond)
@@ -325,10 +325,10 @@ func TestShouldProcessSecret(t *testing.T) {
 	t.Parallel()
 
 	t.Run("normal secret", func(t *testing.T) {
-		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "secret-ibm-cloud-operator"}))
+		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "ibmcloud-operator-secret"}))
 	})
 
 	t.Run("management namespace secret", func(t *testing.T) {
-		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "mynamespace-secret-ibm-cloud-operator"}))
+		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "mynamespace-ibmcloud-operator-secret"}))
 	})
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,20 +5,20 @@
 To check if the operator is correctly started, type:
 
 ```
-kubectl get pod -l "app=ibmcloud-operator" -n ibmcloud-operators
+kubectl get pods -n ibmcloud-operator-system
 ```
 
 if the operator is running, you should get an output similar to the following:
 
 ```
 NAME                                 READY   STATUS    RESTARTS   AGE
-ibmcloud-operator-5885bd58c4-84q52   1/1     Running   0          7s
+ibmcloud-operator-controller-manager-5885bd58c4-84q52   1/1     Running   0          7s
 ```
 
 to check the operator logs, type:
 
 ```
-kubectl logs -n ibmcloud-operators $(kubectl get pod -l "app=ibmcloud-operator" -n ibmcloud-operators -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n ibmcloud-operator-system $(kubectl get pods -n ibmcloud-operator-system -o jsonpath='{.items[0].metadata.name}')
 ```
 
 ## Finding the current git revision for the operator
@@ -26,5 +26,5 @@ kubectl logs -n ibmcloud-operators $(kubectl get pod -l "app=ibmcloud-operator" 
 To find the current git revision for the operator, type:
 
 ```
-kubectl exec -n ibmcloud-operators $(kubectl get pod -l "app=ibmcloud-operator" -n ibmcloud-operators -o jsonpath='{.items[0].metadata.name}') -- cat git-rev
+kubectl exec -n ibmcloud-operator-system $(kubectl get pods -n ibmcloud-operator-system -o jsonpath='{.items[0].metadata.name}') -- cat git-rev
 ```

--- a/hack/configure-operator.sh
+++ b/hack/configure-operator.sh
@@ -187,9 +187,8 @@ store_creds() {
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secret-ibm-cloud-operator
+  name: ibmcloud-operator-secret
   labels:
-    seed.ibm.com/ibmcloud-token: "apikey"
     app.kubernetes.io/name: ibmcloud-operator
   namespace: default
 type: Opaque
@@ -212,7 +211,7 @@ EOT
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-ibm-cloud-operator
+  name: ibmcloud-operator-defaults
   namespace: default
   labels:
     app.kubernetes.io/name: ibmcloud-operator

--- a/internal/cmd/firstsetup/main.go
+++ b/internal/cmd/firstsetup/main.go
@@ -27,8 +27,8 @@ func run() error {
 		return err
 	}
 
-	_, secretErr := k8sClient.CoreV1().Secrets(namespace).Get("secret-ibm-cloud-operator", metav1.GetOptions{})
-	_, configMapErr := k8sClient.CoreV1().ConfigMaps(namespace).Get("config-ibm-cloud-operator", metav1.GetOptions{})
+	_, secretErr := k8sClient.CoreV1().Secrets(namespace).Get("ibmcloud-operator-secret", metav1.GetOptions{})
+	_, configMapErr := k8sClient.CoreV1().ConfigMaps(namespace).Get("ibmcloud-operator-defaults", metav1.GetOptions{})
 	if secretErr == nil && configMapErr == nil {
 		fmt.Println("IBM Cloud Operators configmap and secret already set up. Skipping...")
 		return nil
@@ -38,11 +38,10 @@ func run() error {
 
 	_, err = k8sClient.CoreV1().Secrets(namespace).Create(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret-ibm-cloud-operator",
+			Name:      "ibmcloud-operator-secret",
 			Namespace: namespace,
 			Labels: map[string]string{
-				"seed.ibm.com/ibmcloud-token": "apikey",
-				"app.kubernetes.io/name":      "ibmcloud-operator",
+				"app.kubernetes.io/name": "ibmcloud-operator",
 			},
 		},
 		Data: map[string][]byte{
@@ -56,7 +55,7 @@ func run() error {
 
 	_, err = k8sClient.CoreV1().ConfigMaps(namespace).Create(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-ibm-cloud-operator",
+			Name:      "ibmcloud-operator-defaults",
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/name": "ibmcloud-operator",

--- a/internal/cmd/genolm/deployments.go
+++ b/internal/cmd/genolm/deployments.go
@@ -16,7 +16,7 @@ type Deployment struct {
 
 func getDeployments(output string) ([]Deployment, error) {
 	var deployment appsv1.Deployment
-	deploymentBytes, err := ioutil.ReadFile(filepath.Join(output, "apps_v1_deployment_ibmcloud-operators-controller-manager.yaml"))
+	deploymentBytes, err := ioutil.ReadFile(filepath.Join(output, "apps_v1_deployment_ibmcloud-operator-controller-manager.yaml"))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading generated deployment file. Did kustomize run yet?")
 	}

--- a/internal/ibmcloud/ibmcloud.go
+++ b/internal/ibmcloud/ibmcloud.go
@@ -26,10 +26,10 @@ import (
 
 const (
 	aliasPlan    = "alias"
-	seedInstall  = "ibm-cloud-operator"
-	seedSecret   = "secret-ibm-cloud-operator"
-	seedDefaults = "config-ibm-cloud-operator"
-	seedTokens   = "secret-ibm-cloud-operator-tokens"
+	icoConfigMap = "ibmcloud-operator-config"
+	seedSecret   = "ibmcloud-operator-secret"
+	seedDefaults = "ibmcloud-operator-defaults"
+	seedTokens   = "ibmcloud-operator-tokens"
 )
 
 // Info kept all the needed client API resource and instance Info
@@ -349,7 +349,7 @@ func getIBMCloudContext(instance *ibmcloudv1beta1.Service, cm *v1.ConfigMap) ibm
 
 func getDefaultNamespace(r client.Client) (string, bool) {
 	cm := &v1.ConfigMap{}
-	err := r.Get(context.Background(), types.NamespacedName{Namespace: config.Get().ControllerNamespace, Name: seedInstall}, cm)
+	err := r.Get(context.Background(), types.NamespacedName{Namespace: config.Get().ControllerNamespace, Name: icoConfigMap}, cm)
 	if err != nil {
 		return "default", false
 	}


### PR DESCRIPTION
Renames expected credential and default config names in preparation for v1 release. This change breaks compatibility from v1alpha1.

If someone upgrades without updating these names, nothing bad should happen. ICO will not update resources (other than status) without appropriate credentials.

Copying from below README change:

## Upgrading to 0.3.0+

**IMPORTANT NOTICE:** v0.1 and v0.2 used a different naming scheme for secrets and configmaps. You must copy these to their new names so the upgraded operator continues to update them.

| Legacy names (&lt; v0.3)               | **v0.3 and above**                          | Description                                                                                 |
|:---------------------------------------|:--------------------------------------------|:--------------------------------------------------------------------------------------------|
| secret-ibm-cloud-operator              | **ibmcloud-operator-secret**                | Secret containing API key for its namespace.                                                |
| config-ibm-cloud-operator              | **ibmcloud-operator-defaults**              | ConfigMap containing default values for new resources.                                      |
| ibm-cloud-operator                     | **ibmcloud-operator-config**                | ConfigMap containing the management namespace configuration.                                |
| ${namespace}-secret-ibm-cloud-operator | **${namespace}-ibmcloud-operator-secret**   | Management namespace Secret containing API key for ${namespace}.                            |
| ${namespace}-config-ibm-cloud-operator | **${namespace}-ibmcloud-operator-defaults** | Management namespace ConfigMap containing default values for new resources in ${namespace}. |

