### PR TITLE
Fix Markdown formatting for Operator Hub

### DIFF
--- a/internal/cmd/genolm/templates/clusterserviceversion.yaml
+++ b/internal/cmd/genolm/templates/clusterserviceversion.yaml
@@ -20,7 +20,7 @@ spec:
   # image should be 175x175
   - base64data: {{include "ibmcloud.png" . | base64}}
     mediatype: image/png
-  description: >
+  description: |-
     {{.README | indent 4 | trimSpace}}
   version: {{.Version}}
   replaces: {{.Name}}.v{{.ReplaceVersion}}


### PR DESCRIPTION
Fix formatting for tables, among other things. Apparently YAML is picky about its raw string blocks 😄 