### PR TITLE
Fix default namespace fallback

### DIFF
--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -32,6 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var (
+	testErrNotFound = fmt.Errorf("not found")
+)
+
 func TestService(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -84,7 +88,7 @@ func TestService(t *testing.T) {
 					}, defaultWait, defaultTick)
 
 					_, err = getServiceInstanceFromObj(logger, serviceCopy)
-					assert.True(t, ibmcloud.IsNotFound(err), "Expect service to be deleted")
+					assert.Equal(t, testErrNotFound, err, "Expect service to be deleted")
 				}
 			})
 		}
@@ -126,7 +130,7 @@ func TestService(t *testing.T) {
 		}, defaultWait, defaultTick)
 
 		_, err := getServiceInstanceFromObj(logger, serviceCopy)
-		assert.True(t, ibmcloud.IsNotFound(err))
+		assert.Equal(t, testErrNotFound, err)
 	})
 
 	t.Run("should fail", func(t *testing.T) {
@@ -182,7 +186,7 @@ func getServiceInstanceFromObj(logt logr.Logger, service *ibmcloudv1.Service) (m
 			return instance, nil
 		}
 	}
-	return models.ServiceInstance{}, fmt.Errorf("not found")
+	return models.ServiceInstance{}, testErrNotFound
 }
 
 func TestServiceV1Alpha1Compat(t *testing.T) {
@@ -212,7 +216,7 @@ func TestServiceV1Alpha1Compat(t *testing.T) {
 	}, defaultWait, defaultTick)
 
 	_, err = getServiceInstanceFromObj(logger, serviceCopy)
-	assert.True(t, ibmcloud.IsNotFound(err), "Expect service to be deleted")
+	assert.Equal(t, testErrNotFound, err, "Expect service to be deleted")
 }
 
 func TestServiceV1Beta1Compat(t *testing.T) {
@@ -242,7 +246,7 @@ func TestServiceV1Beta1Compat(t *testing.T) {
 	}, defaultWait, defaultTick)
 
 	_, err = getServiceInstanceFromObj(logger, serviceCopy)
-	assert.True(t, ibmcloud.IsNotFound(err), "Expect service to be deleted")
+	assert.Equal(t, testErrNotFound, err, "Expect service to be deleted")
 }
 
 func TestServiceLoadServiceFailed(t *testing.T) {

--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	testErrNotFound = fmt.Errorf("not found")
+	errNotFoundTest = fmt.Errorf("not found")
 )
 
 func TestService(t *testing.T) {
@@ -88,7 +88,7 @@ func TestService(t *testing.T) {
 					}, defaultWait, defaultTick)
 
 					_, err = getServiceInstanceFromObj(logger, serviceCopy)
-					assert.Equal(t, testErrNotFound, err, "Expect service to be deleted")
+					assert.Equal(t, errNotFoundTest, err, "Expect service to be deleted")
 				}
 			})
 		}
@@ -130,7 +130,7 @@ func TestService(t *testing.T) {
 		}, defaultWait, defaultTick)
 
 		_, err := getServiceInstanceFromObj(logger, serviceCopy)
-		assert.Equal(t, testErrNotFound, err)
+		assert.Equal(t, errNotFoundTest, err)
 	})
 
 	t.Run("should fail", func(t *testing.T) {
@@ -186,7 +186,7 @@ func getServiceInstanceFromObj(logt logr.Logger, service *ibmcloudv1.Service) (m
 			return instance, nil
 		}
 	}
-	return models.ServiceInstance{}, testErrNotFound
+	return models.ServiceInstance{}, errNotFoundTest
 }
 
 func TestServiceV1Alpha1Compat(t *testing.T) {
@@ -216,7 +216,7 @@ func TestServiceV1Alpha1Compat(t *testing.T) {
 	}, defaultWait, defaultTick)
 
 	_, err = getServiceInstanceFromObj(logger, serviceCopy)
-	assert.Equal(t, testErrNotFound, err, "Expect service to be deleted")
+	assert.Equal(t, errNotFoundTest, err, "Expect service to be deleted")
 }
 
 func TestServiceV1Beta1Compat(t *testing.T) {
@@ -246,7 +246,7 @@ func TestServiceV1Beta1Compat(t *testing.T) {
 	}, defaultWait, defaultTick)
 
 	_, err = getServiceInstanceFromObj(logger, serviceCopy)
-	assert.Equal(t, testErrNotFound, err, "Expect service to be deleted")
+	assert.Equal(t, errNotFoundTest, err, "Expect service to be deleted")
 }
 
 func TestServiceLoadServiceFailed(t *testing.T) {

--- a/internal/ibmcloud/errors.go
+++ b/internal/ibmcloud/errors.go
@@ -1,5 +1,0 @@
-package ibmcloud
-
-func IsNotFound(err error) bool {
-	return err != nil && err.Error() == "not found"
-}

--- a/internal/ibmcloud/ibmcloud.go
+++ b/internal/ibmcloud/ibmcloud.go
@@ -19,6 +19,7 @@ import (
 	ibmcloudv1 "github.com/ibm/cloud-operators/api/v1"
 	"github.com/ibm/cloud-operators/internal/config"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -305,7 +306,7 @@ func getConfigOrSecret(logt logr.Logger, r client.Client, instanceNamespace stri
 	}
 	err := r.Get(context.TODO(), types.NamespacedName{Name: objName, Namespace: instanceNamespace}, obj)
 	if err != nil {
-		if IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			err = r.Get(context.TODO(), types.NamespacedName{Name: objName, Namespace: defaultNamespace}, obj)
 			if err != nil {
 				logt.Info("Unable to find secret or config in same namespace or default namespace", "secret or config", objName, "namespace", instanceNamespace, "default namespace", defaultNamespace)

--- a/main.go
+++ b/main.go
@@ -21,11 +21,12 @@ import (
 	"os"
 
 	"github.com/ibm/cloud-operators/controllers"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	zapLog "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	ibmcloudv1 "github.com/ibm/cloud-operators/api/v1"
 	ibmcloudv1alpha1 "github.com/ibm/cloud-operators/api/v1alpha1"
@@ -56,7 +57,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zapLog.New(zapLog.UseDevMode(true), zapLog.RawZapOpts(zap.AddCaller())))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
Fixes #207 

Basic fix was to call the correct `.IsNotFound` func:
```go
ibmcloud.IsNotFound(err) -> k8sErrors.IsNotFound(err)
```