### PR TITLE
Bump memory limit again for higher # of secrets in OpenShift

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,7 +40,7 @@ spec:
           limits:
             cpu: 100m
             # TODO(johnstarich): Reduce back to 30Mi once this is resolved: https://github.com/IBM/cloud-operators/issues/199
-            memory: 125Mi
+            memory: 175Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Root cause and ultimate solution is documented in https://github.com/IBM/cloud-operators/issues/199.

Some folks have even more than 930 secrets, in this case 1200+. This bump to 175MiB should handle up to around 1300 secrets, just to be safe.