### PR TITLE
Remove alpha channel (replaced with stable) to fix issues with OLM & OpenShift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,11 +198,6 @@ operator-courier:
 
 .PHONY: verify-operator-meta
 verify-operator-meta: release-prep operator-courier
-	# Download the alpha channel's last release of CSV and CRDs so it passes validation
-	curl -sL https://github.com/IBM/cloud-operators/releases/download/v0.1.11/001_ibmcloud_v1alpha1_binding.yaml > out/0.1.11_ibmcloud_v1alpha1_binding.yaml
-	curl -sL https://github.com/IBM/cloud-operators/releases/download/v0.1.11/002_ibmcloud_v1alpha1_service.yaml > out/0.1.11_ibmcloud_v1alpha1_service.yaml
-	curl -sL https://github.com/IBM/cloud-operators/releases/download/v0.1.11/ibmcloud_operator.v0.1.11.clusterserviceversion.yaml > out/ibmcloud_operator.v0.1.11.clusterserviceversion.yaml
-	ls out
 	operator-courier verify --ui_validate_io out/
 
 .PHONY: operator-push-test

--- a/internal/cmd/genolm/templates/package.yaml
+++ b/internal/cmd/genolm/templates/package.yaml
@@ -2,6 +2,4 @@ packageName: {{.Name}}
 channels:
   - name: stable
     currentCSV: {{.Name}}.v{{.Version}}
-  - name: alpha
-    currentCSV: ibmcloud-operator.v0.1.11
 defaultChannel: stable


### PR DESCRIPTION
I hit some issues with "missing replaced version from 0.1.11" and `no owned roles` while testing in OpenShift. I think there was some kind of conflicting info in the application version `operator-courier` had pushed, where it was including both the alpha channel's old CRDs+CSV and the new ones.

Removing the old channel and not pushing an image with both seemed to work just fine.