### PR TITLE
Fix CI for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
       script: make lint
     - name: Unit Tests
       script: make coverage-unit
-      if: fork = true
     - name: Tests
       script: make test
       if: fork = false AND type = push  # Don't run int tests too much on the same account in parallel, risks service name conflict failures

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,14 @@ jobs:
   include:
     - name: Lint
       script: make lint
-    - name: Test
-      script: make coverage
-      if: (branch = master AND type = push) OR type = pull_request  # Don't run int tests too much on the same account in parallel, risks service name conflict failures
-    - name: Test End-to-end
-      script: make test-e2e
+    - name: Unit Tests
+      script: make coverage-unit
+      if: fork = true
+    - name: Tests
+      script: make test
+      if: fork = false AND type = push  # Don't run int tests too much on the same account in parallel, risks service name conflict failures
+    #- name: Test End-to-end  # TODO Re-enable once an e2e env is set up.
+    #  script: make test-e2e
     - name: Release Validation
       script: make validate-release RELEASE_VERSION=0.3.0  # Fake version, just used for quick validation
     - name: Release

--- a/Makefile
+++ b/Makefile
@@ -72,20 +72,16 @@ cache/bin/kustomize: cache/bin
 		done
 	[[ "$$(which kustomize)" =~ cache/bin/kustomize ]]
 
-.PHONY: test-fast
-test-fast: generate manifests kubebuilder
-	go test -short -coverprofile cover.out ./...
+.PHONY: test-unit
+test-unit: generate manifests kubebuilder
+	go test -race -short -coverprofile cover.out ./...
 
 .PHONY: test
 test: generate manifests kubebuilder
 	go test -race -coverprofile cover.out ./...
 
-.PHONY: test-e2e
-test-e2e:
-	exit 0  # not implemented
-
-.PHONY: coverage
-coverage: test
+.PHONY: coverage-unit
+coverage-unit: test-unit
 	bash <(curl -s https://codecov.io/bash)
 
 # Build manager binary

--- a/controllers/binding_controller_test.go
+++ b/controllers/binding_controller_test.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 func mustLoadObject(t *testing.T, file string, obj runtime.Object, meta *metav1.ObjectMeta) {
@@ -2292,4 +2293,13 @@ func TestBindingUpdateStatusOnlineFailed(t *testing.T) {
 		},
 		Spec: ibmcloudv1.BindingSpec{},
 	}, client.LastStatusUpdate())
+}
+
+func TestBindingSetupWithManager(t *testing.T) {
+	t.Parallel()
+	mgr := &mockManager{T: t}
+	options := controller.Options{MaxConcurrentReconciles: 1}
+
+	err := (&BindingReconciler{}).SetupWithManager(mgr, options)
+	assert.NoError(t, err)
 }

--- a/controllers/manager_setup_test.go
+++ b/controllers/manager_setup_test.go
@@ -9,11 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 func TestSetUpControllers(t *testing.T) {
@@ -170,4 +174,24 @@ func (m *mockManager) GetClient() client.Client {
 
 func (m *mockManager) GetScheme() *runtime.Scheme {
 	return schemas(m.T)
+}
+
+func (m *mockManager) GetConfig() *rest.Config {
+	return nil
+}
+
+func (m *mockManager) SetFields(interface{}) error {
+	return nil
+}
+
+func (m *mockManager) GetCache() cache.Cache {
+	return nil
+}
+
+func (m *mockManager) GetEventRecorderFor(string) record.EventRecorder {
+	return nil
+}
+
+func (m *mockManager) Add(c manager.Runnable) error {
+	return c.(inject.Injector).InjectFunc(m.SetFields)
 }

--- a/controllers/manager_setup_test.go
+++ b/controllers/manager_setup_test.go
@@ -4,16 +4,125 @@ import (
 	"reflect"
 	"testing"
 	"unicode"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 func TestSetUpControllers(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
+	t.Run("real k8s manager succeeds", func(t *testing.T) {
+		if testing.Short() {
+			t.SkipNow()
+		}
+		_, err := SetUpControllers(k8sManager)
+		require.NoError(t, err)
+	})
 
-	c := setUpControllerDependencies(k8sManager)
+	t.Run("all setups are called correctly", func(t *testing.T) {
+		t.Parallel()
+		mgr := &mockManager{T: t}
 
-	assertNoNilFields(t, c)
+		var reconcilers []reconciler
+		_, setupAllErr := setUpControllers(mgr, func(err *error, r reconciler, mgr manager.Manager, options controller.Options) {
+			reconcilers = append(reconcilers, r)
+		})
+		assert.NoError(t, setupAllErr)
+		require.Len(t, reconcilers, 3)
+		assert.IsType(t, &BindingReconciler{}, reconcilers[0])
+		assert.IsType(t, &ServiceReconciler{}, reconcilers[1])
+		assert.IsType(t, &TokenReconciler{}, reconcilers[2])
+	})
+
+	t.Run("return setup error", func(t *testing.T) {
+		t.Parallel()
+		mgr := &mockManager{T: t}
+
+		_, setupAllErr := setUpControllers(mgr, func(err *error, r reconciler, mgr manager.Manager, options controller.Options) {
+			*err = errors.New("some error")
+		})
+		assert.EqualError(t, setupAllErr, "Unable to setup controller: some error")
+	})
+}
+
+type mockReconciler struct {
+	setup func(mgr ctrl.Manager, options controller.Options) error
+}
+
+func (m *mockReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	return m.setup(mgr, options)
+}
+
+func TestSetupWithManagerOrErr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no error", func(t *testing.T) {
+		someMgr := &mockManager{T: t}
+		someOptions := controller.Options{MaxConcurrentReconciles: 1}
+		r := &mockReconciler{
+			setup: func(mgr manager.Manager, options controller.Options) error {
+				assert.Equal(t, someMgr, mgr)
+				assert.Equal(t, someOptions, options)
+				return nil
+			},
+		}
+		var err error
+
+		setupWithManagerOrErr(&err, r, someMgr, someOptions)
+		assert.NoError(t, err)
+	})
+
+	t.Run("new error", func(t *testing.T) {
+		someMgr := &mockManager{T: t}
+		someOptions := controller.Options{MaxConcurrentReconciles: 1}
+		r := &mockReconciler{
+			setup: func(mgr manager.Manager, options controller.Options) error {
+				assert.Equal(t, someMgr, mgr)
+				assert.Equal(t, someOptions, options)
+				return errors.New("some error")
+			},
+		}
+		var err error
+
+		setupWithManagerOrErr(&err, r, someMgr, someOptions)
+		assert.EqualError(t, err, "some error")
+	})
+
+	t.Run("existing error", func(t *testing.T) {
+		someMgr := &mockManager{T: t}
+		someOptions := controller.Options{MaxConcurrentReconciles: 1}
+		r := &mockReconciler{
+			setup: func(mgr manager.Manager, options controller.Options) error {
+				panic("should not be called")
+			},
+		}
+		err := errors.New("some error")
+
+		setupWithManagerOrErr(&err, r, someMgr, someOptions)
+		assert.EqualError(t, err, "some error")
+	})
+}
+
+func TestSetUpControllerDependencies(t *testing.T) {
+	t.Run("actual k8s manager dependencies", func(t *testing.T) {
+		if testing.Short() {
+			t.SkipNow()
+		}
+		c := setUpControllerDependencies(k8sManager)
+		assertNoNilFields(t, c)
+	})
+
+	t.Run("fake manager for unit test dependencies", func(t *testing.T) {
+		t.Parallel()
+		c := setUpControllerDependencies(&mockManager{T: t})
+		assertNoNilFields(t, c)
+	})
 }
 
 func assertNoNilFields(t *testing.T, v interface{}) {
@@ -48,4 +157,17 @@ func joinFields(a, b string) string {
 		return b
 	}
 	return a + "." + b
+}
+
+type mockManager struct {
+	ctrl.Manager
+	T *testing.T
+}
+
+func (m *mockManager) GetClient() client.Client {
+	return fake.NewFakeClient()
+}
+
+func (m *mockManager) GetScheme() *runtime.Scheme {
+	return schemas(m.T)
 }

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -445,19 +445,12 @@ func (r *ServiceReconciler) deleteService(session *session.Session, logt logr.Lo
 	}
 	if serviceClassType == "CF" {
 		logt.Info("Deleting ", instance.ObjectMeta.Name, instance.Spec.ServiceClass)
-		err := r.DeleteCFServiceInstance(session, instance.Status.InstanceID, logt)
-		if err != nil {
-			return err
-		}
-
-	} else { // Resource is not CF
-		logt.Info("Deleting ", instance.ObjectMeta.Name, instance.Spec.ServiceClass)
-		err := r.DeleteResourceServiceInstance(session, instance.Status.InstanceID, logt)
-		if err != nil {
-			return err
-		}
+		return r.DeleteCFServiceInstance(session, instance.Status.InstanceID, logt)
 	}
-	return nil
+
+	// Resource is not CF
+	logt.Info("Deleting ", instance.ObjectMeta.Name, instance.Spec.ServiceClass)
+	return r.DeleteResourceServiceInstance(session, instance.Status.InstanceID, logt)
 }
 
 func getExternalName(instance *ibmcloudv1.Service) string {

--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -2434,3 +2434,141 @@ func TestServiceSetupWithManager(t *testing.T) {
 	err := (&ServiceReconciler{}).SetupWithManager(mgr, options)
 	assert.NoError(t, err)
 }
+
+func TestDeleteService(t *testing.T) {
+	t.Parallel()
+	const (
+		namespace   = "mynamespace"
+		serviceName = "myservice"
+	)
+	scheme := schemas(t)
+	instance := &ibmcloudv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+		Status: ibmcloudv1.ServiceStatus{
+			Plan:         "Lite",
+			ServiceClass: "service-name",
+			InstanceID:   "myinstanceid",
+		},
+		Spec: ibmcloudv1.ServiceSpec{
+			Plan:         "Lite",
+			ServiceClass: "service-name",
+		},
+	}
+
+	t.Run("alias is a no-op", func(t *testing.T) {
+		instanceCopy := *instance
+		instanceCopy.Spec.Plan = aliasPlan
+		instanceCopy.Status.Plan = aliasPlan
+		r := &ServiceReconciler{
+			Client: newMockClient(
+				fake.NewFakeClientWithScheme(scheme, &instanceCopy),
+				MockConfig{},
+			),
+			Log:    testLogger(t),
+			Scheme: scheme,
+		}
+
+		err := r.deleteService(nil, r.Log, &instanceCopy, "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty instance ID is a no-op", func(t *testing.T) {
+		instanceCopy := *instance
+		instanceCopy.Status.InstanceID = ""
+		r := &ServiceReconciler{
+			Client: newMockClient(
+				fake.NewFakeClientWithScheme(scheme, &instanceCopy),
+				MockConfig{},
+			),
+			Log:    testLogger(t),
+			Scheme: scheme,
+		}
+
+		err := r.deleteService(nil, r.Log, &instanceCopy, "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("delete CF service", func(t *testing.T) {
+		someErr := fmt.Errorf("some error")
+		r := &ServiceReconciler{
+			Client: newMockClient(
+				fake.NewFakeClientWithScheme(scheme, instance),
+				MockConfig{},
+			),
+			Log:    testLogger(t),
+			Scheme: scheme,
+
+			DeleteCFServiceInstance: func(session *session.Session, instanceID string, logt logr.Logger) error {
+				return someErr
+			},
+		}
+
+		err := r.deleteService(nil, r.Log, instance, "CF")
+		assert.Equal(t, someErr, err)
+	})
+
+	t.Run("delete resource service", func(t *testing.T) {
+		someErr := fmt.Errorf("some error")
+		r := &ServiceReconciler{
+			Client: newMockClient(
+				fake.NewFakeClientWithScheme(scheme, instance),
+				MockConfig{},
+			),
+			Log:    testLogger(t),
+			Scheme: scheme,
+
+			DeleteResourceServiceInstance: func(session *session.Session, instanceID string, logt logr.Logger) error {
+				return someErr
+			},
+		}
+
+		err := r.deleteService(nil, r.Log, instance, "")
+		assert.Equal(t, someErr, err)
+	})
+}
+
+func TestExternalName(t *testing.T) {
+	t.Parallel()
+
+	const someName = "some external name"
+
+	t.Run("external name is set", func(t *testing.T) {
+		assert.Equal(t,
+			someName,
+			getExternalName(&ibmcloudv1.Service{
+				Spec: ibmcloudv1.ServiceSpec{
+					ExternalName: someName,
+				},
+			}),
+		)
+	})
+
+	t.Run("fallback to name", func(t *testing.T) {
+		assert.Equal(t,
+			someName,
+			getExternalName(&ibmcloudv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: someName,
+				},
+			}),
+		)
+	})
+}
+
+func TestGetState(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		state    string
+		expected string
+	}{
+		{state: "unknown", expected: "unknown"},
+		{state: "succeeded", expected: "Online"},
+		{state: "active", expected: "Online"},
+		{state: "provisioned", expected: "Online"},
+	} {
+		t.Run(tc.state+" "+tc.expected, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getState(tc.state))
+		})
+	}
+}

--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 var (
@@ -2423,4 +2424,13 @@ func TestServiceUpdateStatusError(t *testing.T) {
 			},
 		}, r.Client.(MockClient).LastStatusUpdate())
 	})
+}
+
+func TestServiceSetupWithManager(t *testing.T) {
+	t.Parallel()
+	mgr := &mockManager{T: t}
+	options := controller.Options{MaxConcurrentReconciles: 1}
+
+	err := (&ServiceReconciler{}).SetupWithManager(mgr, options)
+	assert.NoError(t, err)
 }

--- a/controllers/token_controller.go
+++ b/controllers/token_controller.go
@@ -128,12 +128,16 @@ func (r *TokenReconciler) SetupWithManager(mgr ctrl.Manager, options controller.
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		For(&corev1.Secret{}).
-		WithEventFilter(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool { return shouldProcessSecret(e.Meta) },
-			DeleteFunc: func(e event.DeleteEvent) bool { return shouldProcessSecret(e.Meta) },
-			UpdateFunc: func(e event.UpdateEvent) bool { return shouldProcessSecret(e.MetaNew) },
-		}).
+		WithEventFilter(eventsFilter()).
 		Complete(r)
+}
+
+func eventsFilter() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return shouldProcessSecret(e.Meta) },
+		DeleteFunc: func(e event.DeleteEvent) bool { return shouldProcessSecret(e.Meta) },
+		UpdateFunc: func(e event.UpdateEvent) bool { return shouldProcessSecret(e.MetaNew) },
+	}
 }
 
 func shouldProcessSecret(meta metav1.Object) bool {

--- a/controllers/token_controller_test.go
+++ b/controllers/token_controller_test.go
@@ -17,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 var (
@@ -331,4 +332,13 @@ func TestShouldProcessSecret(t *testing.T) {
 	t.Run("management namespace secret", func(t *testing.T) {
 		assert.True(t, shouldProcessSecret(&metav1.ObjectMeta{Name: "mynamespace-ibmcloud-operator-secret"}))
 	})
+}
+
+func TestTokenSetupWithManager(t *testing.T) {
+	t.Parallel()
+	mgr := &mockManager{T: t}
+	options := controller.Options{MaxConcurrentReconciles: 1}
+
+	err := (&TokenReconciler{}).SetupWithManager(mgr, options)
+	assert.NoError(t, err)
 }

--- a/controllers/token_controller_test.go
+++ b/controllers/token_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 var (
@@ -341,4 +342,18 @@ func TestTokenSetupWithManager(t *testing.T) {
 
 	err := (&TokenReconciler{}).SetupWithManager(mgr, options)
 	assert.NoError(t, err)
+}
+
+func TestTokenEventsFilter(t *testing.T) {
+	t.Parallel()
+
+	filter := eventsFilter()
+	shouldProcessEvent := &metav1.ObjectMeta{Name: icoSecretName}
+	shouldNotProcessEvent := &metav1.ObjectMeta{}
+	assert.True(t, filter.CreateFunc(event.CreateEvent{Meta: shouldProcessEvent}))
+	assert.False(t, filter.CreateFunc(event.CreateEvent{Meta: shouldNotProcessEvent}))
+	assert.True(t, filter.DeleteFunc(event.DeleteEvent{Meta: shouldProcessEvent}))
+	assert.False(t, filter.DeleteFunc(event.DeleteEvent{Meta: shouldNotProcessEvent}))
+	assert.True(t, filter.UpdateFunc(event.UpdateEvent{MetaNew: shouldProcessEvent}))
+	assert.False(t, filter.UpdateFunc(event.UpdateEvent{MetaNew: shouldNotProcessEvent}))
 }


### PR DESCRIPTION
Since integration tests only work on non-forks (Travis secrets are unavailable on forks), this makes sure PRs are at least partially validated before being merged.

Maintainers can also run the integration tests against the PR locally before merging.

Unblocks #223 and #226.