### PR TITLE
upgrade Go to 1.15.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.15.8 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
fixes for the following are contained in 1.15.8
CVE-2021-3114
CVE-2021-3115