### PR TITLE
Automated OperatorHub releases

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-08-04T19:07:32Z",
+  "generated_at": "2021-09-01T04:46:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -57,7 +57,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.39.dss",
+  "version": "0.13.1+ibm.45.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     #- name: Test End-to-end  # TODO Re-enable once an e2e env is set up.
     #  script: make test-e2e
     - name: Release Validation
-      script: make validate-release RELEASE_VERSION=0.3.0  # Fake version, just used for quick validation
+      script: make validate-release RELEASE_VERSION=1000.0.0  # Arbitrarily high version, just used for quick validation
     - name: Release
       stage: release
       script: make -e RELEASE_VERSION="${TRAVIS_TAG/v}" release

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ services:
 
 jobs:
   include:
+    - name: Temp release
+      script: make -e RELEASE_VERSION="1.0.10" release
     - name: Lint
       script: make lint
     - name: Unit Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 jobs:
   include:
     - name: Temp release
-      script: make -e RELEASE_VERSION="1.0.10" release
+      script: make -e RELEASE_VERSION="1.0.10" tmp
     - name: Lint
       script: make lint
     - name: Unit Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ services:
 
 jobs:
   include:
-    - name: Temp release
-      script: make -e RELEASE_VERSION="1.0.10" tmp
     - name: Lint
       script: make lint
     - name: Unit Tests

--- a/Makefile
+++ b/Makefile
@@ -199,9 +199,6 @@ release-operatorhub:
 .PHONY: release
 release: release-prep docker-push release-operatorhub
 
-.PHONY: tmp
-tmp: release-prep release-operatorhub
-
 # Validates release artifacts.
 # TODO add validation for operator-courier. Currently hitting WAY too many issues with Travis CI and Python deps.
 .PHONY: validate-release

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,18 @@ release-prep: kustomize manifests out
 	kustomize build config/default --output out/
 	ulimit -n 1000 && go run ./internal/cmd/genolm --version ${RELEASE_VERSION}
 
+.PHONY: release-operatorhub
+release-operatorhub:
+	go run ./internal/cmd/release \
+		-version "${RELEASE_VERSION}" \
+		-csv "out/ibmcloud_operator.v${RELEASE_VERSION}.clusterserviceversion.yaml" \
+		-package out/ibmcloud-operator.package.yaml \
+		-draft=$${RELEASE_DRAFT:-false} \
+		-fork-org "$${RELEASE_FORK_ORG}" \
+		-gh-token "$${RELEASE_GH_TOKEN}"
+
 .PHONY: release
-release: release-prep docker-push
+release: release-prep docker-push release-operatorhub
 
 # Validates release artifacts.
 # TODO add validation for operator-courier. Currently hitting WAY too many issues with Travis CI and Python deps.

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,9 @@ release-operatorhub:
 .PHONY: release
 release: release-prep docker-push release-operatorhub
 
+.PHONY: tmp
+tmp: release-prep release-operatorhub
+
 # Validates release artifacts.
 # TODO add validation for operator-courier. Currently hitting WAY too many issues with Travis CI and Python deps.
 .PHONY: validate-release

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,9 @@ release-operatorhub:
 		-package out/ibmcloud-operator.package.yaml \
 		-draft=$${RELEASE_DRAFT:-false} \
 		-fork-org "$${RELEASE_FORK_ORG}" \
-		-gh-token "$${RELEASE_GH_TOKEN}"
+		-gh-token "$${RELEASE_GH_TOKEN}" \
+		-signoff-name "$${RELEASE_GIT_NAME}" \
+		-signoff-email "$${RELEASE_GIT_EMAIL}"
 
 .PHONY: release
 release: release-prep docker-push release-operatorhub

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ release-operatorhub:
 		-draft=$${RELEASE_DRAFT:-false} \
 		-fork-org "$${RELEASE_FORK_ORG}" \
 		-gh-token "$${RELEASE_GH_TOKEN}" \
-		-signoff-name "${RELEASE_GIT_NAME}" \
+		-signoff-name "$${RELEASE_GIT_NAME}" \
 		-signoff-email "$${RELEASE_GIT_EMAIL}"
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ cache/kubebuilder_${KUBEBUILDER_VERSION}/bin: cache
 		rm -rf cache/kubebuilder_${KUBEBUILDER_VERSION}; \
 		mkdir -p cache/kubebuilder_${KUBEBUILDER_VERSION}; \
 		set -o pipefail; \
-		curl -L https://go.kubebuilder.io/dl/${KUBEBUILDER_VERSION}/$(shell go env GOOS)/$(shell go env GOARCH) | tar --strip-components=1 -xz -C ./cache/kubebuilder_${KUBEBUILDER_VERSION}; \
+		curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_$(shell go env GOOS)_$(shell go env GOARCH).tar.gz | tar --strip-components=1 -xz -C ./cache/kubebuilder_${KUBEBUILDER_VERSION}; \
 	fi
 
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ release-operatorhub:
 		-draft=$${RELEASE_DRAFT:-false} \
 		-fork-org "$${RELEASE_FORK_ORG}" \
 		-gh-token "$${RELEASE_GH_TOKEN}" \
-		-signoff-name "$${RELEASE_GIT_NAME}" \
+		-signoff-name "${RELEASE_GIT_NAME}" \
 		-signoff-email "$${RELEASE_GIT_EMAIL}"
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ release-operatorhub:
 		-version "${RELEASE_VERSION}" \
 		-csv "out/ibmcloud_operator.v${RELEASE_VERSION}.clusterserviceversion.yaml" \
 		-package out/ibmcloud-operator.package.yaml \
+		-crd-glob 'out/apiextensions.k8s.io_v1beta1_customresourcedefinition_*.ibmcloud.ibm.com.yaml' \
 		-draft=$${RELEASE_DRAFT:-false} \
 		-fork-org "$${RELEASE_FORK_ORG}" \
 		-gh-token "$${RELEASE_GH_TOKEN}" \

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ release-operatorhub:
 		-version "${RELEASE_VERSION}" \
 		-csv "out/ibmcloud_operator.v${RELEASE_VERSION}.clusterserviceversion.yaml" \
 		-package out/ibmcloud-operator.package.yaml \
-		-crd-glob 'out/apiextensions.k8s.io_v1beta1_customresourcedefinition_*.ibmcloud.ibm.com.yaml' \
+		-crd-glob 'out/apiextensions.k8s.io_*_customresourcedefinition_*.ibmcloud.ibm.com.yaml' \
 		-draft=$${RELEASE_DRAFT:-false} \
 		-fork-org "$${RELEASE_FORK_ORG}" \
 		-gh-token "$${RELEASE_GH_TOKEN}" \

--- a/internal/cmd/genolm/templates/clusterserviceversion.yaml
+++ b/internal/cmd/genolm/templates/clusterserviceversion.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{.Name}}.v{{.Version}}
   namespace: placeholder
   annotations:
+    # Prevent cluster upgrades to OpenShift Version 4.9 when this bundle is installed on the cluster.
+    # Remove once Kubernetes v1.22 is supported by removing deprecated kind versions.
+    olm.properties: |-
+      [{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]
     alm-examples: |-
       {{.Examples | json | indent 6 | trimSpace}}
     capabilities: Basic Install

--- a/internal/cmd/release/github.go
+++ b/internal/cmd/release/github.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type GitHub struct {
+	token string
+
+	doRequest func(*http.Request) (*http.Response, error)
+}
+
+func newGitHub(token string) *GitHub {
+	return &GitHub{
+		token:     token,
+		doRequest: http.DefaultClient.Do,
+	}
+}
+
+func (g *GitHub) request(ctx context.Context, method string, url url.URL, requestBody, responseBody interface{}) error {
+	var requestReader io.Reader
+	if requestBody != nil {
+		requestBytes, err := json.Marshal(requestBody)
+		if err != nil {
+			return err
+		}
+		requestReader = bytes.NewReader(requestBytes)
+	}
+	url.Scheme = "https"
+	url.Host = "github.com"
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), requestReader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+g.token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := g.doRequest(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		responseBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.Errorf("Request failed with %d: %s", resp.StatusCode, string(responseBytes))
+	}
+	if responseBody != nil {
+		return json.NewDecoder(resp.Body).Decode(responseBody)
+	}
+	return nil
+}
+
+type SetFileContentsParams struct {
+	Org, Repo      string // Required
+	BranchName     string // Required
+	FilePath       string // Required. Repo-relative file path.
+	Message        string
+	OldContentsSHA string // Optional if file is new, required otherwise.
+	NewContents    []byte // Required
+}
+
+// SetFileContents creates or updates a file on the given branch.
+//
+// Reference for updating a file (proposing changes via commit) reference: https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents
+func (g *GitHub) SetFileContents(ctx context.Context, params SetFileContentsParams) error {
+	if params.Message == "" {
+		params.Message = "Update " + params.FilePath
+	}
+	body := struct {
+		Message string `json:"message"` // Required. The commit message.
+		Content []byte `json:"content"` // Required. The new file content, using Base64 encoding.
+		SHA     string `json:"sha"`     // Required if you are updating a file. The blob SHA of the file being replaced.
+		Branch  string `json:"branch"`  // The branch name. Default: the repository’s default branch (usually master)
+	}{
+		Message: params.Message,
+		Content: params.NewContents,
+		SHA:     params.OldContentsSHA,
+		Branch:  params.BranchName,
+	}
+	return g.request(ctx, http.MethodPut, url.URL{Path: fmt.Sprintf("/repos/%s/%s/contents/%s", params.Org, params.Repo, params.FilePath)}, body, nil)
+}
+
+type FileContents struct {
+	Type    string // "file", "dir", etc
+	Content []byte
+	SHA     string
+}
+
+func (g *GitHub) GetFileContents(ctx context.Context, org, repo, branchName, repoFilePath string) (FileContents, error) {
+	var resp FileContents
+	u := url.URL{
+		Path: fmt.Sprintf("/repos/%s/%s/contents/%s", org, repo, repoFilePath),
+	}
+	if branchName != "" {
+		u.RawQuery = url.Values{
+			"ref": []string{branchName},
+		}.Encode()
+	}
+	err := g.request(ctx, http.MethodGet, u, nil, &resp)
+	return resp, err
+}

--- a/internal/cmd/release/github.go
+++ b/internal/cmd/release/github.go
@@ -84,8 +84,9 @@ type SetFileContentsParams struct {
 //
 // Reference for updating a file (proposing changes via commit) reference: https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents
 func (g *GitHub) SetFileContents(ctx context.Context, params SetFileContentsParams) error {
-	if params.Message == "" {
-		params.Message = "Update " + params.FilePath
+	message := "Update " + params.FilePath
+	if params.Message != "" {
+		message = params.Message
 	}
 	body := struct {
 		Message string `json:"message"` // Required. The commit message.
@@ -93,7 +94,7 @@ func (g *GitHub) SetFileContents(ctx context.Context, params SetFileContentsPara
 		SHA     string `json:"sha"`     // Required if you are updating a file. The blob SHA of the file being replaced.
 		Branch  string `json:"branch"`  // The branch name. Default: the repository’s default branch (usually master)
 	}{
-		Message: params.Message,
+		Message: message,
 		Content: params.NewContents,
 		SHA:     params.OldContentsSHA,
 		Branch:  params.BranchName,

--- a/internal/cmd/release/github.go
+++ b/internal/cmd/release/github.go
@@ -13,8 +13,7 @@ import (
 )
 
 type GitHub struct {
-	token string
-
+	token     string
 	doRequest func(*http.Request) (*http.Response, error)
 }
 

--- a/internal/cmd/release/github_test.go
+++ b/internal/cmd/release/github_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGitHub(t *testing.T) {
+	gh := newGitHub("abc123")
+	assert.Equal(t, "abc123", gh.token)
+	assert.NotNil(t, gh.doRequest)
+}

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -84,6 +84,9 @@ func run(args Args, deps Deps) error {
 	if args.GitUserEmail == "" {
 		return errors.New("Git user email is required")
 	}
+	if args.GitUserName == "John" {
+		panic("nope")
+	}
 	version := "v" + strings.TrimPrefix(args.Version, "v")
 
 	csvContents, err := ioutil.ReadFile(args.CSVFile)

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -1,5 +1,7 @@
-// Command release publishes a new release of IBM Cloud Operator.
+// Command release publishes a new release of IBM Cloud Operator on Operator Hub by opening PRs.
+//
 // Picks up pre-generated output files and creates pull requests in the appropriate repos.
+// See: https://operatorhub.io/operator/ibmcloud-operator
 package main
 
 import (

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -51,12 +51,10 @@ func main() {
 }
 
 const (
-	//kubernetesOperatorsOrg  = "k8s-operatorhub"
-	kubernetesOperatorsOrg  = "johnstarich"
+	kubernetesOperatorsOrg  = "k8s-operatorhub"
 	kubernetesOperatorsRepo = "community-operators"
 
-	//openshiftOperatorsOrg   = "redhat-openshift-ecosystem"
-	openshiftOperatorsOrg  = "johnstarich"
+	openshiftOperatorsOrg  = "redhat-openshift-ecosystem"
 	openshiftOperatorsRepo = "community-operators-prod"
 
 	defaultBranch = "main"

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -84,9 +84,6 @@ func run(args Args, deps Deps) error {
 	if args.GitUserEmail == "" {
 		return errors.New("Git user email is required")
 	}
-	if args.GitUserName == "John" {
-		panic("nope")
-	}
 	version := "v" + strings.TrimPrefix(args.Version, "v")
 
 	csvContents, err := ioutil.ReadFile(args.CSVFile)

--- a/internal/cmd/release/main_test.go
+++ b/internal/cmd/release/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		version     string
+		csvFile     bool
+		packageFile bool
+		expectErr   string
+	}{
+		{
+			description: "no CSV file",
+			version:     "v1.2.3",
+			csvFile:     false,
+			packageFile: true,
+			expectErr:   "failed to read cluster service version file: open : no such file or directory",
+		},
+		{
+			description: "no package file",
+			version:     "v1.2.3",
+			csvFile:     true,
+			packageFile: false,
+			expectErr:   "failed to read package file: open : no such file or directory",
+		},
+		{
+			description: "no version",
+			version:     "",
+			csvFile:     true,
+			packageFile: true,
+			expectErr:   "version is required",
+		},
+		{
+			description: "happy path",
+			version:     "v1.2.3",
+			csvFile:     true,
+			packageFile: true,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			dir := t.TempDir()
+			args := Args{
+				Version: tc.version,
+			}
+			if tc.csvFile {
+				args.CSVFile = filepath.Join(dir, "csv.yaml")
+				require.NoError(t, ioutil.WriteFile(args.CSVFile, []byte(`CSV contents`), 0600))
+			}
+			if tc.packageFile {
+				args.PackageFile = filepath.Join(dir, "package.yaml")
+				require.NoError(t, ioutil.WriteFile(args.PackageFile, []byte(`CSV contents`), 0600))
+			}
+			const (
+				k8sPackageSHA       = "abc123"
+				openshiftPackageSHA = "def456"
+			)
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "https", r.URL.Scheme)
+				assert.Equal(t, "github.com", r.URL.Host)
+				switch r.Method {
+				case http.MethodGet:
+					switch r.URL.Path {
+					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
+						fmt.Fprintf(w, `{"sha": %q}`, k8sPackageSHA)
+					case "/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
+						fmt.Fprintf(w, `{"sha": %q}`, openshiftPackageSHA)
+					default:
+						t.Fatal("Unrecognized github.com GET path:", r.URL.Path)
+					}
+				case http.MethodPut:
+					body, err := ioutil.ReadAll(r.Body)
+					require.NoError(t, err)
+					switch r.URL.Path {
+					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
+						assert.Contains(t, string(body), fmt.Sprintf(`"sha":%q`, k8sPackageSHA))
+						fmt.Fprint(w, `{}`)
+					case "/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
+						assert.Contains(t, string(body), fmt.Sprintf(`"sha":%q`, openshiftPackageSHA))
+						fmt.Fprint(w, `{}`)
+					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml",
+						"/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml":
+						fmt.Fprint(w, `{}`)
+					default:
+						t.Fatal("Unrecognized github.com PUT path:", r.URL.Path)
+					}
+				default:
+					t.Fatal("Unrecognized github.com HTTP method:", r.Method, r.URL.Path)
+				}
+			})
+			deps := Deps{
+				GitHub: &GitHub{doRequest: func(req *http.Request) (*http.Response, error) {
+					recorder := httptest.NewRecorder()
+					handler.ServeHTTP(recorder, req)
+					return recorder.Result(), nil
+				}},
+			}
+			err := run(args, deps)
+			if tc.expectErr != "" {
+				assert.EqualError(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/cmd/release/main_test.go
+++ b/internal/cmd/release/main_test.go
@@ -22,13 +22,13 @@ func TestRun(t *testing.T) {
 		someVersion   = "v1.2.3"
 		someUserName  = "Joe Schmoe"
 		someUserEmail = "joe@example.com"
-		someCRDGlob   = "apiextensions.k8s.io_*_customresourcedefinition_*.ibmcloud.ibm.com.yaml"
 	)
 	dir := t.TempDir()
 	someCSVFile := filepath.Join(dir, "ibmcloud-operator.package.yaml")
 	require.NoError(t, ioutil.WriteFile(someCSVFile, []byte(`CSV contents`), 0600))
 	somePackageFile := filepath.Join(dir, "ibmcloud_operator.v1.2.3.clusterserviceversion.yaml")
 	require.NoError(t, ioutil.WriteFile(somePackageFile, []byte(`package contents`), 0600))
+	someCRDGlob := filepath.Join(dir, "apiextensions.k8s.io_*_customresourcedefinition_*.ibmcloud.ibm.com.yaml")
 	someCRDFile := filepath.Join(dir, "apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml")
 	require.NoError(t, ioutil.WriteFile(someCRDFile, []byte(`CRD contents`), 0600))
 
@@ -95,9 +95,11 @@ OpenShift PR opened: %s
 			}
 			var (
 				k8sMainSHA          = newSHA()
+				k8sCRDSHA           = newSHA()
 				k8sPackageSHA       = newSHA()
 				k8sCSVSHA           = newSHA()
 				openshiftMainSHA    = newSHA()
+				openshiftCRDSHA     = newSHA()
 				openshiftPackageSHA = newSHA()
 				openshiftCSVSHA     = newSHA()
 			)
@@ -109,24 +111,28 @@ OpenShift PR opened: %s
 			)
 			handler := newMockServerHandler(t, []mockRequest{
 				// k8s
-				{http.MethodGet, k8sRepo + "/git/ref/heads/main"},                                                                                 // get default branch from upstream
-				{http.MethodPatch, k8sForkRepo + "/git/refs/heads/main"},                                                                          // force update fork default branch to same commit
-				{http.MethodGet, k8sForkRepo + "/git/ref/heads/release-v1.2.3"},                                                                   // get release branch info
-				{http.MethodPatch, k8sForkRepo + "/git/refs/heads/release-v1.2.3"},                                                                // branch exists, force update to same commit
-				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // get old CSV hash
-				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // update CSV
-				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // get old package hash
-				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // update package
+				{http.MethodGet, k8sRepo + "/git/ref/heads/main"},                  // get default branch from upstream
+				{http.MethodPatch, k8sForkRepo + "/git/refs/heads/main"},           // force update fork default branch to same commit
+				{http.MethodGet, k8sForkRepo + "/git/ref/heads/release-v1.2.3"},    // get release branch info
+				{http.MethodPatch, k8sForkRepo + "/git/refs/heads/release-v1.2.3"}, // branch exists, force update to same commit
+				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}, // get old CRD hash
+				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}, // update CRD
+				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"},                               // get old CSV hash
+				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"},                               // update CSV
+				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                                                          // get old package hash
+				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                                                          // update package
 
 				// openshift
-				{http.MethodGet, ocRepo + "/git/ref/heads/main"},                                                                                 // get default branch from upstream
-				{http.MethodPatch, ocForkRepo + "/git/refs/heads/main"},                                                                          // force update fork default branch to same commit
-				{http.MethodGet, ocForkRepo + "/git/ref/heads/release-v1.2.3"},                                                                   // get release branch info
-				{http.MethodPost, ocForkRepo + "/git/refs"},                                                                                      // branch does not exist, create new one at same commit
-				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // get old CSV hash
-				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // update CSV
-				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // get old package hash
-				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // update package
+				{http.MethodGet, ocRepo + "/git/ref/heads/main"},               // get default branch from upstream
+				{http.MethodPatch, ocForkRepo + "/git/refs/heads/main"},        // force update fork default branch to same commit
+				{http.MethodGet, ocForkRepo + "/git/ref/heads/release-v1.2.3"}, // get release branch info
+				{http.MethodPost, ocForkRepo + "/git/refs"},                    // branch does not exist, create new one at same commit
+				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}, // get old CRD hash
+				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}, // update CRD
+				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"},                               // get old CSV hash
+				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"},                               // update CSV
+				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                                                          // get old package hash
+				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                                                          // update package
 
 				// pulls
 				{http.MethodGet, k8sRepo + "/pulls"}, // check existing k8s PRs (found one, don't open anew)
@@ -154,6 +160,12 @@ OpenShift PR opened: %s
 					}`
 				},
 				{http.MethodPatch, "/repos/some-fork/community-operators/git/refs/heads/release-v1.2.3"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{}`
+				},
+				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{"sha": %q}`, k8sCRDSHA)
+				},
+				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}: func(r *http.Request, body string) (int, string) {
 					return http.StatusOK, `{}`
 				},
 				{http.MethodGet, "/repos/some-fork/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"}: func(r *http.Request, body string) (int, string) {
@@ -188,6 +200,12 @@ OpenShift PR opened: %s
 				{http.MethodPost, "/repos/some-fork/community-operators-prod/git/refs"}: func(r *http.Request, body string) (int, string) {
 					assert.Contains(t, body, fmt.Sprintf(`"sha":%q`, openshiftMainSHA))
 					assert.Contains(t, body, `"ref":"refs/heads/release-v1.2.3"`)
+					return http.StatusOK, `{}`
+				},
+				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{"sha": %q}`, openshiftCRDSHA)
+				},
+				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml"}: func(r *http.Request, body string) (int, string) {
 					return http.StatusOK, `{}`
 				},
 				{http.MethodGet, "/repos/some-fork/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"}: func(r *http.Request, body string) (int, string) {
@@ -277,7 +295,7 @@ func newMockServerHandler(t *testing.T, expectRequests []mockRequest, responses 
 		t.Helper()
 		assert.Equal(t, len(expectRequests), m.currentRequest, "Number of handled requests must equal expected request count")
 
-		if !assert.Empty(t, m.unusedResponses, "Found responses that were not used. Fix or remove these:") {
+		if !t.Failed() && !assert.Empty(t, m.unusedResponses, "Found responses that were not used. Fix or remove these:") {
 			for req := range m.unusedResponses {
 				t.Logf("Unused: %#v", req)
 			}

--- a/internal/cmd/release/main_test.go
+++ b/internal/cmd/release/main_test.go
@@ -17,58 +17,61 @@ import (
 
 func TestRun(t *testing.T) {
 	const (
-		someFork       = "some fork"
-		someVersion    = "v1.2.3"
+		someFork      = "some-fork"
+		someToken     = "abc123"
+		someVersion   = "v1.2.3"
+		someUserName  = "Joe Schmoe"
+		someUserEmail = "joe@example.com"
+		someCRDGlob   = "apiextensions.k8s.io_*_customresourcedefinition_*.ibmcloud.ibm.com.yaml"
+	)
+	dir := t.TempDir()
+	someCSVFile := filepath.Join(dir, "ibmcloud-operator.package.yaml")
+	require.NoError(t, ioutil.WriteFile(someCSVFile, []byte(`CSV contents`), 0600))
+	somePackageFile := filepath.Join(dir, "ibmcloud_operator.v1.2.3.clusterserviceversion.yaml")
+	require.NoError(t, ioutil.WriteFile(somePackageFile, []byte(`package contents`), 0600))
+	someCRDFile := filepath.Join(dir, "apiextensions.k8s.io_v1beta1_customresourcedefinition_mycrd.ibmcloud.ibm.com.yaml")
+	require.NoError(t, ioutil.WriteFile(someCRDFile, []byte(`CRD contents`), 0600))
+
+	const (
 		existingK8sPR  = "https://github.com/org/repo/pull/123"
 		newOpenShiftPR = "https://github.com/org/repo/pull/456"
 	)
 	for _, tc := range []struct {
 		description string
-		version     string
-		forkOrg     string
-		csvFile     bool
-		packageFile bool
+		args        []string
 		expectOut   string
 		expectErr   string
 	}{
 		{
-			description: "no CSV file",
-			version:     someVersion,
-			forkOrg:     someFork,
-			csvFile:     false,
-			packageFile: true,
-			expectErr:   "failed to read cluster service version file: open : no such file or directory",
+			description: "missing flags",
+			args:        []string{},
+			expectErr: `Missing required flags:
+    -crd-glob
+    -csv
+    -fork-org
+    -gh-token
+    -package
+    -signoff-email
+    -signoff-name
+    -version`,
 		},
 		{
-			description: "no package file",
-			version:     someVersion,
-			forkOrg:     someFork,
-			csvFile:     true,
-			packageFile: false,
-			expectErr:   "failed to read package file: open : no such file or directory",
-		},
-		{
-			description: "no version",
-			version:     "",
-			forkOrg:     someFork,
-			csvFile:     true,
-			packageFile: true,
-			expectErr:   "version is required",
-		},
-		{
-			description: "no fork org",
-			version:     someVersion,
-			forkOrg:     "",
-			csvFile:     true,
-			packageFile: true,
-			expectErr:   "fork org is required",
+			description: "invalid flag type",
+			args:        []string{"-draft=no"},
+			expectErr:   `invalid boolean value "no" for -draft: parse error`,
 		},
 		{
 			description: "happy path",
-			version:     someVersion,
-			forkOrg:     someFork,
-			csvFile:     true,
-			packageFile: true,
+			args: []string{
+				"-crd-glob", someCRDGlob,
+				"-csv", someCSVFile,
+				"-fork-org", someFork,
+				"-gh-token", someToken,
+				"-package", somePackageFile,
+				"-signoff-email", someUserEmail,
+				"-signoff-name", someUserName,
+				"-version", someVersion,
+			},
 			expectOut: fmt.Sprintf(`
 Kubernetes PR opened: %s
 OpenShift PR opened: %s
@@ -76,90 +79,159 @@ OpenShift PR opened: %s
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			dir := t.TempDir()
-			var output bytes.Buffer
-			args := Args{
-				GitHubToken: "some token",
-				Version:     tc.version,
-				ForkOrg:     tc.forkOrg,
-				Output:      &output,
-			}
-			if tc.csvFile {
-				args.CSVFile = filepath.Join(dir, "csv.yaml")
-				require.NoError(t, ioutil.WriteFile(args.CSVFile, []byte(`CSV contents`), 0600))
-			}
-			if tc.packageFile {
-				args.PackageFile = filepath.Join(dir, "package.yaml")
-				require.NoError(t, ioutil.WriteFile(args.PackageFile, []byte(`CSV contents`), 0600))
-			}
-			const (
-				k8sPackageSHA       = "abc123"
-				openshiftPackageSHA = "def456"
-			)
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "https", r.URL.Scheme)
-				assert.Equal(t, "api.github.com", r.URL.Host)
-				if r.Body == nil {
-					r.Body = ioutil.NopCloser(bytes.NewReader(nil))
+			args, err := parseArgs(tc.args, ioutil.Discard)
+			if err != nil {
+				if tc.expectErr != "" {
+					assert.EqualError(t, err, tc.expectErr)
+					return
 				}
-				body, err := ioutil.ReadAll(r.Body)
 				require.NoError(t, err)
-				switch r.Method {
-				case http.MethodGet:
-					switch r.URL.Path {
-					case "/repos/k8s-operatorhub/community-operators/pulls":
-						query := url.Values{
-							"head": []string{someFork + ":release-" + someVersion + "-"},
+			}
+
+			startSHA := 0
+			newSHA := func() string {
+				startSHA++
+				return fmt.Sprintf("%06d", startSHA)
+			}
+			var (
+				k8sMainSHA          = newSHA()
+				k8sPackageSHA       = newSHA()
+				k8sCSVSHA           = newSHA()
+				openshiftMainSHA    = newSHA()
+				openshiftPackageSHA = newSHA()
+				openshiftCSVSHA     = newSHA()
+			)
+			const (
+				k8sRepo     = "/repos/k8s-operatorhub/community-operators"
+				k8sForkRepo = "/repos/some-fork/community-operators"
+				ocRepo      = "/repos/redhat-openshift-ecosystem/community-operators-prod"
+				ocForkRepo  = "/repos/some-fork/community-operators-prod"
+			)
+			handler := newMockServerHandler(t, []mockRequest{
+				// k8s
+				{http.MethodGet, k8sRepo + "/git/ref/heads/main"},                                                                                 // get default branch from upstream
+				{http.MethodPatch, k8sForkRepo + "/git/refs/heads/main"},                                                                          // force update fork default branch to same commit
+				{http.MethodGet, k8sForkRepo + "/git/ref/heads/release-v1.2.3"},                                                                   // get release branch info
+				{http.MethodPatch, k8sForkRepo + "/git/refs/heads/release-v1.2.3"},                                                                // branch exists, force update to same commit
+				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // get old CSV hash
+				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // update CSV
+				{http.MethodGet, k8sForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // get old package hash
+				{http.MethodPut, k8sForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // update package
+
+				// openshift
+				{http.MethodGet, ocRepo + "/git/ref/heads/main"},                                                                                 // get default branch from upstream
+				{http.MethodPatch, ocForkRepo + "/git/refs/heads/main"},                                                                          // force update fork default branch to same commit
+				{http.MethodGet, ocForkRepo + "/git/ref/heads/release-v1.2.3"},                                                                   // get release branch info
+				{http.MethodPost, ocForkRepo + "/git/refs"},                                                                                      // branch does not exist, create new one at same commit
+				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // get old CSV hash
+				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}, // update CSV
+				{http.MethodGet, ocForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // get old package hash
+				{http.MethodPut, ocForkRepo + "/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"},                            // update package
+
+				// pulls
+				{http.MethodGet, k8sRepo + "/pulls"}, // check existing k8s PRs (found one, don't open anew)
+				{http.MethodGet, ocRepo + "/pulls"},  // check existing openshift PRs
+				{http.MethodPost, ocRepo + "/pulls"}, // open new openshift PR
+			}, map[mockRequest]mockRequester{
+				// k8s
+				{http.MethodGet, "/repos/k8s-operatorhub/community-operators/git/ref/heads/main"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{
+						"object": {
+							"sha": %q
 						}
-						assert.True(t, strings.HasPrefix(r.URL.RawQuery, query.Encode()), "Query = %s", r.URL.RawQuery)
-						fmt.Fprintf(w, `[
-							{"html_url": %q}
-						]`, existingK8sPR)
-					case "/repos/redhat-openshift-ecosystem/community-operators-prod/pulls":
-						fmt.Fprint(w, `[]`)
-					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
-						fmt.Fprintf(w, `{"sha": %q}`, k8sPackageSHA)
-					case "/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
-						fmt.Fprintf(w, `{"sha": %q}`, openshiftPackageSHA)
-					default:
-						t.Fatal("Unrecognized github.com GET path:", r.URL.Path)
-					}
-				case http.MethodPut:
-					switch r.URL.Path {
-					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
-						assert.Contains(t, string(body), fmt.Sprintf(`"sha":%q`, k8sPackageSHA))
-						fmt.Fprint(w, `{}`)
-					case "/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
-						assert.Contains(t, string(body), fmt.Sprintf(`"sha":%q`, openshiftPackageSHA))
-						fmt.Fprint(w, `{}`)
-					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml",
-						"/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml":
-						fmt.Fprint(w, `{}`)
-					default:
-						t.Fatal("Unrecognized github.com PUT path:", r.URL.Path)
-					}
-				case http.MethodPost:
-					switch r.URL.Path {
-					case "/repos/redhat-openshift-ecosystem/community-operators-prod/pulls":
-						bodyStr := string(body)
-						assert.Contains(t, bodyStr, `"head":"`+someFork+`:release-`+someVersion+`-`)
-						assert.Contains(t, bodyStr, `"base":"main"`)
-						fmt.Fprintf(w, `{"html_url":%q}`, newOpenShiftPR)
-					default:
-						t.Fatal("Unrecognized github.com POST path:", r.URL.Path)
-					}
-				default:
-					t.Fatal("Unrecognized github.com HTTP method:", r.Method, r.URL.Path)
-				}
+					}`, k8sMainSHA)
+				},
+				{http.MethodPatch, "/repos/some-fork/community-operators/git/refs/heads/main"}: func(r *http.Request, body string) (int, string) {
+					assert.Contains(t, body, fmt.Sprintf(`"sha":%q`, k8sMainSHA))
+					assert.Contains(t, body, `"force":true`)
+					return http.StatusOK, `{}`
+				},
+				{http.MethodGet, "/repos/some-fork/community-operators/git/ref/heads/release-v1.2.3"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{
+						"object": {
+							"sha": "unexpected"
+						}
+					}`
+				},
+				{http.MethodPatch, "/repos/some-fork/community-operators/git/refs/heads/release-v1.2.3"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{}`
+				},
+				{http.MethodGet, "/repos/some-fork/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{"sha": %q}`, k8sPackageSHA)
+				},
+				{http.MethodGet, "/repos/some-fork/community-operators/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{"sha": %q}`, k8sCSVSHA)
+				},
+				{http.MethodPut, "/repos/some-fork/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{}`
+				},
+				{http.MethodPut, "/repos/some-fork/community-operators/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{}`
+				},
+
+				// openshift
+				{http.MethodGet, "/repos/redhat-openshift-ecosystem/community-operators-prod/git/ref/heads/main"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{
+						"object": {
+							"sha": %q
+						}
+					}`, openshiftMainSHA)
+				},
+				{http.MethodPatch, "/repos/some-fork/community-operators-prod/git/refs/heads/main"}: func(r *http.Request, body string) (int, string) {
+					assert.Contains(t, body, fmt.Sprintf(`"sha":%q`, openshiftMainSHA))
+					assert.Contains(t, body, `"force":true`)
+					return http.StatusOK, `{}`
+				},
+				{http.MethodGet, "/repos/some-fork/community-operators-prod/git/ref/heads/release-v1.2.3"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusNotFound, ``
+				},
+				{http.MethodPost, "/repos/some-fork/community-operators-prod/git/refs"}: func(r *http.Request, body string) (int, string) {
+					assert.Contains(t, body, fmt.Sprintf(`"sha":%q`, openshiftMainSHA))
+					assert.Contains(t, body, `"ref":"refs/heads/release-v1.2.3"`)
+					return http.StatusOK, `{}`
+				},
+				{http.MethodGet, "/repos/some-fork/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{"sha": %q}`, openshiftPackageSHA)
+				},
+				{http.MethodGet, "/repos/some-fork/community-operators-prod/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, fmt.Sprintf(`{"sha": %q}`, openshiftCSVSHA)
+				},
+				{http.MethodPut, "/repos/some-fork/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{}`
+				},
+				{http.MethodPut, "/repos/some-fork/community-operators-prod/contents/operators/ibmcloud-operator/1.2.3/ibmcloud_operator.v1.2.3.clusterserviceversion.yaml"}: func(r *http.Request, body string) (int, string) {
+					return http.StatusOK, `{}`
+				},
+
+				// pulls
+				{http.MethodGet, "/repos/k8s-operatorhub/community-operators/pulls"}: func(r *http.Request, body string) (int, string) {
+					// k8s PR already exists
+					query := url.Values{"head": []string{"some-fork:release-v1.2.3"}}
+					assert.Contains(t, r.URL.RawQuery, query.Encode())
+					return http.StatusOK, fmt.Sprintf(`[
+						{"html_url": %q}
+					]`, existingK8sPR)
+				},
+				{http.MethodGet, "/repos/redhat-openshift-ecosystem/community-operators-prod/pulls"}: func(r *http.Request, body string) (int, string) {
+					// openshift PR does not exist
+					return http.StatusOK, `[]`
+				},
+				{http.MethodPost, "/repos/redhat-openshift-ecosystem/community-operators-prod/pulls"}: func(r *http.Request, body string) (int, string) {
+					assert.Contains(t, body, `"head":"some-fork:release-v1.2.3"`)
+					assert.Contains(t, body, `"base":"main"`)
+					return http.StatusOK, fmt.Sprintf(`{"html_url":%q}`, newOpenShiftPR)
+				},
 			})
+			var output bytes.Buffer
 			deps := Deps{
+				Output: &output,
 				GitHub: &GitHub{doRequest: func(req *http.Request) (*http.Response, error) {
 					recorder := httptest.NewRecorder()
 					handler.ServeHTTP(recorder, req)
 					return recorder.Result(), nil
 				}},
 			}
-			err := run(args, deps)
+			err = run(args, deps)
 			assert.Equal(t, strings.TrimPrefix(tc.expectOut, "\n"), output.String())
 			if tc.expectErr != "" {
 				assert.EqualError(t, err, tc.expectErr)
@@ -168,4 +240,77 @@ OpenShift PR opened: %s
 			require.NoError(t, err)
 		})
 	}
+}
+
+type mockRequest struct {
+	Method string
+	Path   string
+}
+
+type mockRequester func(r *http.Request, body string) (int, string)
+
+type mockServerHandler struct {
+	testingT        *testing.T
+	currentRequest  int
+	requests        []mockRequest
+	responses       map[mockRequest]mockRequester
+	unusedResponses map[mockRequest]bool
+}
+
+// newMockServerHandler returns a mock HTTP server handler for the given requests and responses
+//
+// expectRequestSeq is a list of expected requests in the order they are expected.
+// responses is a map of a request's HTTP method & URL path to a response generator.
+func newMockServerHandler(t *testing.T, expectRequests []mockRequest, responses map[mockRequest]mockRequester) http.Handler {
+	t.Helper()
+	m := &mockServerHandler{
+		testingT:        t,
+		requests:        expectRequests,
+		responses:       responses,
+		unusedResponses: make(map[mockRequest]bool),
+	}
+	for k := range responses {
+		m.unusedResponses[k] = true
+	}
+
+	t.Cleanup(func() {
+		t.Helper()
+		assert.Equal(t, len(expectRequests), m.currentRequest, "Number of handled requests must equal expected request count")
+
+		if !assert.Empty(t, m.unusedResponses, "Found responses that were not used. Fix or remove these:") {
+			for req := range m.unusedResponses {
+				t.Logf("Unused: %#v", req)
+			}
+		}
+	})
+	return m
+}
+
+func (m *mockServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.testingT.Helper()
+	mockReq := mockRequest{
+		Method: r.Method,
+		Path:   r.URL.Path,
+	}
+	if assert.Less(m.testingT, m.currentRequest, len(m.requests), "Received more requests than expected. Extra request:", mockReq) {
+		assert.Equal(m.testingT, m.requests[m.currentRequest], mockReq)
+	}
+	delete(m.unusedResponses, mockReq)
+	m.currentRequest++
+
+	requester, ok := m.responses[mockReq]
+	if !assert.True(m.testingT, ok, "Request type not found: %#v", mockReq) {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if r.Body == nil {
+		r.Body = ioutil.NopCloser(bytes.NewReader(nil))
+	}
+	requestBody, err := ioutil.ReadAll(r.Body)
+	assert.NoError(m.testingT, err)
+
+	status, responseBody := requester(r, string(requestBody))
+	w.WriteHeader(status)
+	fmt.Fprint(w, responseBody)
 }

--- a/internal/cmd/release/main_test.go
+++ b/internal/cmd/release/main_test.go
@@ -79,9 +79,10 @@ OpenShift PR opened: %s
 			dir := t.TempDir()
 			var output bytes.Buffer
 			args := Args{
-				Version: tc.version,
-				ForkOrg: tc.forkOrg,
-				Output:  &output,
+				GitHubToken: "some token",
+				Version:     tc.version,
+				ForkOrg:     tc.forkOrg,
+				Output:      &output,
 			}
 			if tc.csvFile {
 				args.CSVFile = filepath.Join(dir, "csv.yaml")
@@ -97,7 +98,7 @@ OpenShift PR opened: %s
 			)
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "https", r.URL.Scheme)
-				assert.Equal(t, "github.com", r.URL.Host)
+				assert.Equal(t, "api.github.com", r.URL.Host)
 				if r.Body == nil {
 					r.Body = ioutil.NopCloser(bytes.NewReader(nil))
 				}

--- a/internal/cmd/release/main_test.go
+++ b/internal/cmd/release/main_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,23 +16,33 @@ import (
 )
 
 func TestRun(t *testing.T) {
+	const (
+		someFork       = "some fork"
+		someVersion    = "v1.2.3"
+		existingK8sPR  = "https://github.com/org/repo/pull/123"
+		newOpenShiftPR = "https://github.com/org/repo/pull/456"
+	)
 	for _, tc := range []struct {
 		description string
 		version     string
+		forkOrg     string
 		csvFile     bool
 		packageFile bool
+		expectOut   string
 		expectErr   string
 	}{
 		{
 			description: "no CSV file",
-			version:     "v1.2.3",
+			version:     someVersion,
+			forkOrg:     someFork,
 			csvFile:     false,
 			packageFile: true,
 			expectErr:   "failed to read cluster service version file: open : no such file or directory",
 		},
 		{
 			description: "no package file",
-			version:     "v1.2.3",
+			version:     someVersion,
+			forkOrg:     someFork,
 			csvFile:     true,
 			packageFile: false,
 			expectErr:   "failed to read package file: open : no such file or directory",
@@ -37,21 +50,38 @@ func TestRun(t *testing.T) {
 		{
 			description: "no version",
 			version:     "",
+			forkOrg:     someFork,
 			csvFile:     true,
 			packageFile: true,
 			expectErr:   "version is required",
 		},
 		{
-			description: "happy path",
-			version:     "v1.2.3",
+			description: "no fork org",
+			version:     someVersion,
+			forkOrg:     "",
 			csvFile:     true,
 			packageFile: true,
+			expectErr:   "fork org is required",
+		},
+		{
+			description: "happy path",
+			version:     someVersion,
+			forkOrg:     someFork,
+			csvFile:     true,
+			packageFile: true,
+			expectOut: fmt.Sprintf(`
+Kubernetes PR opened: %s
+OpenShift PR opened: %s
+`, existingK8sPR, newOpenShiftPR),
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			dir := t.TempDir()
+			var output bytes.Buffer
 			args := Args{
 				Version: tc.version,
+				ForkOrg: tc.forkOrg,
+				Output:  &output,
 			}
 			if tc.csvFile {
 				args.CSVFile = filepath.Join(dir, "csv.yaml")
@@ -68,9 +98,24 @@ func TestRun(t *testing.T) {
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "https", r.URL.Scheme)
 				assert.Equal(t, "github.com", r.URL.Host)
+				if r.Body == nil {
+					r.Body = ioutil.NopCloser(bytes.NewReader(nil))
+				}
+				body, err := ioutil.ReadAll(r.Body)
+				require.NoError(t, err)
 				switch r.Method {
 				case http.MethodGet:
 					switch r.URL.Path {
+					case "/repos/k8s-operatorhub/community-operators/pulls":
+						query := url.Values{
+							"head": []string{someFork + ":release-" + someVersion + "-"},
+						}
+						assert.True(t, strings.HasPrefix(r.URL.RawQuery, query.Encode()), "Query = %s", r.URL.RawQuery)
+						fmt.Fprintf(w, `[
+							{"html_url": %q}
+						]`, existingK8sPR)
+					case "/repos/redhat-openshift-ecosystem/community-operators-prod/pulls":
+						fmt.Fprint(w, `[]`)
 					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
 						fmt.Fprintf(w, `{"sha": %q}`, k8sPackageSHA)
 					case "/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
@@ -79,8 +124,6 @@ func TestRun(t *testing.T) {
 						t.Fatal("Unrecognized github.com GET path:", r.URL.Path)
 					}
 				case http.MethodPut:
-					body, err := ioutil.ReadAll(r.Body)
-					require.NoError(t, err)
 					switch r.URL.Path {
 					case "/repos/k8s-operatorhub/community-operators/contents/operators/ibmcloud-operator/ibmcloud-operator.package.yaml":
 						assert.Contains(t, string(body), fmt.Sprintf(`"sha":%q`, k8sPackageSHA))
@@ -94,6 +137,16 @@ func TestRun(t *testing.T) {
 					default:
 						t.Fatal("Unrecognized github.com PUT path:", r.URL.Path)
 					}
+				case http.MethodPost:
+					switch r.URL.Path {
+					case "/repos/redhat-openshift-ecosystem/community-operators-prod/pulls":
+						bodyStr := string(body)
+						assert.Contains(t, bodyStr, `"head":"`+someFork+`:release-`+someVersion+`-`)
+						assert.Contains(t, bodyStr, `"base":"main"`)
+						fmt.Fprintf(w, `{"html_url":%q}`, newOpenShiftPR)
+					default:
+						t.Fatal("Unrecognized github.com POST path:", r.URL.Path)
+					}
 				default:
 					t.Fatal("Unrecognized github.com HTTP method:", r.Method, r.URL.Path)
 				}
@@ -106,6 +159,7 @@ func TestRun(t *testing.T) {
 				}},
 			}
 			err := run(args, deps)
+			assert.Equal(t, strings.TrimPrefix(tc.expectOut, "\n"), output.String())
 			if tc.expectErr != "" {
 				assert.EqualError(t, err, tc.expectErr)
 				return

--- a/internal/cmd/release/main_test.go
+++ b/internal/cmd/release/main_test.go
@@ -15,6 +15,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMainRun(t *testing.T) {
+	t.Run("missing args", func(t *testing.T) {
+		var out bytes.Buffer
+		exitCode := runMain(nil, &out, &out)
+		assert.Equal(t, 2, exitCode)
+		assert.Contains(t, out.String(), `Missing required flags:`)
+	})
+
+	t.Run("failed run", func(t *testing.T) {
+		var out bytes.Buffer
+		exitCode := runMain([]string{
+			"-crd-glob=.",
+			"-csv=.",
+			"-fork-org=.",
+			"-gh-token=.",
+			"-package=.",
+			"-signoff-email=.",
+			"-signoff-name=.",
+			"-version=.",
+		}, &out, &out)
+		assert.Equal(t, 1, exitCode)
+		assert.Contains(t, out.String(), `Release failed:`)
+	})
+}
+
 func TestRun(t *testing.T) {
 	const (
 		someFork      = "some-fork"
@@ -73,8 +98,8 @@ func TestRun(t *testing.T) {
 				"-version", someVersion,
 			},
 			expectOut: fmt.Sprintf(`
-Kubernetes PR opened: %s
-OpenShift PR opened: %s
+Kubernetes PR: %s
+OpenShift PR: %s
 `, existingK8sPR, newOpenShiftPR),
 		},
 	} {

--- a/internal/pipe/pipe.go
+++ b/internal/pipe/pipe.go
@@ -1,0 +1,20 @@
+package pipe
+
+type Op func() error
+
+func Chain(ops []Op) error {
+	for _, op := range ops {
+		err := op()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ErrIf(cond bool, err error) error {
+	if cond {
+		return err
+	}
+	return nil
+}

--- a/internal/pipe/pipe_test.go
+++ b/internal/pipe/pipe_test.go
@@ -1,0 +1,28 @@
+package pipe
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChain(t *testing.T) {
+	assert.NoError(t, Chain(nil))
+
+	assert.NoError(t, Chain([]Op{
+		func() error { return nil },
+	}))
+
+	assert.EqualError(t, Chain([]Op{
+		func() error { return nil },
+		func() error { return errors.New("foo") },
+		func() error { return errors.New("bar") },
+	}), "foo")
+}
+
+func TestErrIf(t *testing.T) {
+	assert.NoError(t, ErrIf(true, nil))
+	assert.NoError(t, ErrIf(false, errors.New("foo")))
+	assert.EqualError(t, ErrIf(true, errors.New("foo")), "foo")
+}


### PR DESCRIPTION
Automates releases to OperatorHub.io for both Kubernetes and OpenShift operators.

`v1.0.10` was published using the automation from this PR:
* K8s: https://github.com/k8s-operatorhub/community-operators/commit/6da2bc06afcb0ce59ccadc867642c3ca83eb02f2
* OpenShift: https://github.com/redhat-openshift-ecosystem/community-operators-prod/commit/662ebdc3c800eaf057543ac48ca1e51d223cafe9


Fixes https://github.com/IBM/cloud-operators/issues/247