### PR TITLE
Publish GitHub Release automatically, skip draft phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
           file_glob: true
           skip_cleanup: true
           overwrite: true
-          draft: true
           on:
             all_branches: true # earlier 'if:' limits this
             repo: IBM/cloud-operators


### PR DESCRIPTION

Publish GitHub Release automatically, skip draft phase.
Now that we're auto-publishing OperatorHub releases, the manual step no longer makes sense.
