### PR TITLE
Remove "self-healing" when service state inconsistent

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -529,11 +529,6 @@ func (r *ServiceReconciler) updateStatus(session *session.Session, logt logr.Log
 		setStatusFieldsFromSpec(instance, resourceContext)
 		err := r.Status().Update(context.Background(), instance)
 		if err != nil {
-			r.Log.Info("Failed to update online status, will delete external resource ", instance.ObjectMeta.Name, err.Error())
-			errD := r.deleteService(session, logt, instance, serviceClassType)
-			if errD != nil {
-				r.Log.Info("Failed to delete external resource, operator state and external resource might be in an inconsistent state", instance.ObjectMeta.Name, errD.Error())
-			}
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/service_controller_test.go
+++ b/controllers/service_controller_test.go
@@ -2326,10 +2326,6 @@ func TestServiceUpdateStatusFailed(t *testing.T) {
 		),
 		Log:    testLogger(t),
 		Scheme: scheme,
-
-		DeleteResourceServiceInstance: func(session *session.Session, instanceID string, logt logr.Logger) error {
-			return fmt.Errorf("failed to delete") // only gets logged, no error handling
-		},
 	}
 
 	result, err := r.updateStatus(nil, r.Log, instance, ibmcloudv1.ResourceContext{}, "myinstanceid", "state", "")


### PR DESCRIPTION

In the early days of IBM Cloud Operator, self-healing was added with the intent to reconcile a Service in an inconsistent state by recreating the service instance.

This can be very destructive for critical services like databases, so this PR removes the service deletion.
