### PR TITLE
Rotate and remove secrets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.15.x"
+  - "1.16.x"
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ test: generate manifests kubebuilder
 
 .PHONY: coverage-unit
 coverage-unit: test-unit
-	bash <(curl -s https://codecov.io/bash)
+	go install github.com/mattn/goveralls@v0.0.11
+	$(GOBIN)/goveralls -coverprofile="cover.out" -service=travis-ci
 
 # Build manager binary
 .PHONY: manager

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/IBM/cloud-operators.svg?branch=master)](https://travis-ci.com/IBM/cloud-operators)
 [![Go Report Card](https://goreportcard.com/badge/github.com/IBM/cloud-operators)](https://goreportcard.com/report/github.com/IBM/cloud-operators)
-[![codecov.io](https://codecov.io/github/IBM/cloud-operators/coverage.svg?branch=master)](https://codecov.io/github/IBM/cloud-operators?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/IBM/cloud-operators/badge.svg)](https://coveralls.io/github/IBM/cloud-operators)
 ![Docker Pulls](https://img.shields.io/docker/pulls/cloudoperators/ibmcloud-operator)
 [![GoDoc](https://godoc.org/github.com/IBM/cloud-operators?status.svg)](https://godoc.org/github.com/IBM/cloud-operators)
 


### PR DESCRIPTION
* Use $RELEASE_GH_TOKEN for GitHub releases. Deleted the encrypted Travis key.
* Replace CodeCov with coveralls.io for coverage with hard-versioned open source `goveralls` tool. Deleted the CODECOV_TOKEN and didn't need a token for Coveralls. Changed to avoid problems like [this](https://about.codecov.io/security-update/) in the future.

I went through all of `goveralls@v0.0.11` and vetted it as well. Nothing remotely suspicious 😉 

Successful GitHub Releases deploy here (draft, now deleted): https://app.travis-ci.com/github/IBM/cloud-operators/jobs/543101026
