### PR TITLE
Enable GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.17.13
+          cache: true
+
+      - name: Lint
+        run: make lint
+
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Validate release artifacts
+        run: make validate-release RELEASE_VERSION=1000.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,3 @@
+{
+  "settingsInheritedFrom": "ibm-mend-config/mend-config@main"
+}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ IMG ?= cloudoperators/ibmcloud-operator:${RELEASE_VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+# Use the configured GOBIN, falling back to GOPATH/bin.
 GOBIN := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ KUBEVAL_KUBE_VERSION=1.18.1
 # Set PATH to pick up cached tools. The additional 'sed' is required for cross-platform support of quoting the args to 'env'
 SHELL := /usr/bin/env PATH=$(shell echo ${PWD}/cache/bin:${KUBEBUILDER_ASSETS}:${PATH} | sed 's/ /\\ /g') bash
 
-# Version to create release. Value is set in .travis.yml's release job
+# Version to create release. Value is set by the release job
 RELEASE_VERSION ?= 0.0.0
 # Image URL to use all building/pushing image targets
 IMG ?= cloudoperators/ibmcloud-operator:${RELEASE_VERSION}
@@ -17,11 +17,7 @@ IMG ?= cloudoperators/ibmcloud-operator:${RELEASE_VERSION}
 CRD_OPTIONS ?= "crd"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+GOBIN := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 
 .PHONY: all
 all: manager
@@ -140,7 +136,6 @@ lint: lint-deps
 	golangci-lint run
 	gosec -conf .gosec.json ./...
 	find . -name '*.*sh' | xargs shellcheck --color
-	go list -json -m all | docker run --rm -i sonatypecommunity/nancy:latest sleuth
 
 .PHONY: lint-fix
 lint-fix: lint-deps

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/IBM/cloud-operators.svg?branch=master)](https://travis-ci.com/IBM/cloud-operators)
+[![CI](https://github.com/IBM/cloud-operators/actions/workflows/ci.yml/badge.svg)](https://github.com/IBM/cloud-operators/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/IBM/cloud-operators)](https://goreportcard.com/report/github.com/IBM/cloud-operators)
 [![Coverage Status](https://coveralls.io/repos/github/IBM/cloud-operators/badge.svg)](https://coveralls.io/github/IBM/cloud-operators)
 ![Docker Pulls](https://img.shields.io/docker/pulls/cloudoperators/ibmcloud-operator)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-- manager.yaml
+  - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: cloudoperators/ibmcloud-operator
-  newTag: 1.0.0
+  - name: controller
+    newName: cloudoperators/ibmcloud-operator
+    newTag: 1.0.0


### PR DESCRIPTION
As Travis CI is broken, first we have to unjam the CI, then we can roll out the rest of the fixes.

Note that this is not a 1:1 Travis - GH Actions migration just yet